### PR TITLE
Compare clusters

### DIFF
--- a/scripts/summary2csv.pl
+++ b/scripts/summary2csv.pl
@@ -1,0 +1,70 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use v5.10;
+
+my @rows = ();
+my %current = ();
+while(<>) {
+	# Ignore blank lines.
+	next if /^\s*$/;
+
+	# Change current file when we hit a block.
+	if(/^== (.*) ==$/) {
+		push @rows, {%current} if $current{'filename'};
+		%current = ();
+		$current{'filename'} = $1;
+		next;
+	}
+
+	die "No current file!" unless $current{'filename'};
+
+	# Count line.
+	die "Unable to read line: $_" unless /^(\w+): (\d+) \(([\d\.]+)%\)$/;
+	my $field_name = $1;
+	my $field_count = $2;
+	my $field_percentage = $3;
+
+	die "Duplicate field found for $field_name" if exists $current{$field_name}; 
+	$current{$field_name} = {
+		'count' => $field_count,
+		'percentage' => $field_percentage,
+	};
+}
+
+# Write out headers.
+use Data::Dumper;
+my @headers = (
+	'File',
+	'Total identifiers',
+	'Total comparisons',
+	'Total comparisons %'
+);
+my %field_names_unsorted = map { $_ => 1 } map { keys(%$_) } @rows;
+delete $field_names_unsorted{'TOTAL'};
+delete $field_names_unsorted{'filename'};
+my @field_names = map { ($_, $_ . ' %') } sort keys %field_names_unsorted;
+
+say join "\t", (@headers, map { ucfirst lc } @field_names);
+
+for my $row (@rows) {
+
+	my $total_count = 0;
+	my $total_percentage = 0;
+	my $row_text = "";
+
+	for my $fieldname (@field_names) {
+		next if substr ($fieldname, -1) eq '%';
+
+		my $count = $row->{$fieldname}->{'count'} // 0;
+		my $percentage = $row->{$fieldname}->{'percentage'} // 0;
+
+		$total_count += $count;
+		$total_percentage += $percentage;
+
+		$row_text = $row_text . "\t$count\t$percentage"
+	}
+
+	say "$row->{'filename'}\t\t$total_count\t$total_percentage$row_text"
+}

--- a/scripts/summary2csv.pl
+++ b/scripts/summary2csv.pl
@@ -33,6 +33,8 @@ while(<>) {
 	};
 }
 
+push @rows, {%current} if $current{'filename'};
+
 # Write out headers.
 use Data::Dumper;
 my @headers = (
@@ -46,7 +48,7 @@ delete $field_names_unsorted{'TOTAL'};
 delete $field_names_unsorted{'filename'};
 my @field_names = map { ($_, $_ . ' %') } sort keys %field_names_unsorted;
 
-say join "\t", (@headers, map { ucfirst lc } @field_names);
+say join "\t", (@headers, (map { ucfirst lc } @field_names));
 
 for my $row (@rows) {
 

--- a/src/main/scala/org/renci/babel/utils/MemoryUtils.scala
+++ b/src/main/scala/org/renci/babel/utils/MemoryUtils.scala
@@ -1,0 +1,11 @@
+package org.renci.babel.utils
+
+object MemoryUtils {
+  def getMemorySummary: String = {
+    val runtime = Runtime.getRuntime
+
+    def bytesToGB(b: Long): Double = b.toDouble / (1e+9)
+
+    f"${bytesToGB(runtime.freeMemory())}%.2f GB free out of ${bytesToGB(runtime.totalMemory())}%.2f GB (${bytesToGB(runtime.maxMemory())}%.2f max GB)"
+  }
+}

--- a/src/main/scala/org/renci/babel/utils/MemoryUtils.scala
+++ b/src/main/scala/org/renci/babel/utils/MemoryUtils.scala
@@ -8,8 +8,11 @@ object MemoryUtils {
 
     val memoryUsed = runtime.totalMemory() - runtime.freeMemory()
 
+    val memoryUsedOfAvailPercent = memoryUsed.toDouble/runtime.totalMemory()*100
+    val memoryUsedOfMaxPercent = memoryUsed.toDouble/runtime.maxMemory()*100
+
     f"${bytesToGB(runtime.freeMemory())}%.2f GB free out of ${bytesToGB(
         runtime.totalMemory()
-      )}%.2f GB (${bytesToGB(memoryUsed)}%.2f GB used out of ${bytesToGB(runtime.maxMemory())}%.2f GB max)"
+      )}%.2f GB (${bytesToGB(memoryUsed)}%.2f GB used out of ${bytesToGB(runtime.maxMemory())}%.2f GB max: ${memoryUsedOfAvailPercent}%.2f%% of avail, ${memoryUsedOfMaxPercent}%.2f%% of max)"
   }
 }

--- a/src/main/scala/org/renci/babel/utils/MemoryUtils.scala
+++ b/src/main/scala/org/renci/babel/utils/MemoryUtils.scala
@@ -6,6 +6,8 @@ object MemoryUtils {
 
     def bytesToGB(b: Long): Double = b.toDouble / (1e+9)
 
-    f"${bytesToGB(runtime.freeMemory())}%.2f GB free out of ${bytesToGB(runtime.totalMemory())}%.2f GB (${bytesToGB(runtime.maxMemory())}%.2f max GB)"
+    f"${bytesToGB(runtime.freeMemory())}%.2f GB free out of ${bytesToGB(
+        runtime.totalMemory()
+      )}%.2f GB (${bytesToGB(runtime.maxMemory())}%.2f max GB)"
   }
 }

--- a/src/main/scala/org/renci/babel/utils/MemoryUtils.scala
+++ b/src/main/scala/org/renci/babel/utils/MemoryUtils.scala
@@ -10,6 +10,6 @@ object MemoryUtils {
 
     f"${bytesToGB(runtime.freeMemory())}%.2f GB free out of ${bytesToGB(
         runtime.totalMemory()
-      )}%.2f GB (${bytesToGB(runtime.maxMemory())}%.2f GB max, ${bytesToGB(memoryUsed)}%.2f GB used)"
+      )}%.2f GB (${bytesToGB(memoryUsed)}%.2f GB used out of ${bytesToGB(runtime.maxMemory())}%.2f GB max)"
   }
 }

--- a/src/main/scala/org/renci/babel/utils/MemoryUtils.scala
+++ b/src/main/scala/org/renci/babel/utils/MemoryUtils.scala
@@ -8,8 +8,9 @@ object MemoryUtils {
 
     val memoryUsed = runtime.totalMemory() - runtime.freeMemory()
 
-    val memoryUsedOfAvailPercent = memoryUsed.toDouble/runtime.totalMemory()*100
-    val memoryUsedOfMaxPercent = memoryUsed.toDouble/runtime.maxMemory()*100
+    val memoryUsedOfAvailPercent =
+      memoryUsed.toDouble / runtime.totalMemory() * 100
+    val memoryUsedOfMaxPercent = memoryUsed.toDouble / runtime.maxMemory() * 100
 
     f"${bytesToGB(runtime.freeMemory())}%.2f GB free out of ${bytesToGB(
         runtime.totalMemory()

--- a/src/main/scala/org/renci/babel/utils/MemoryUtils.scala
+++ b/src/main/scala/org/renci/babel/utils/MemoryUtils.scala
@@ -6,8 +6,10 @@ object MemoryUtils {
 
     def bytesToGB(b: Long): Double = b.toDouble / (1e+9)
 
+    val memoryUsed = runtime.totalMemory() - runtime.freeMemory()
+
     f"${bytesToGB(runtime.freeMemory())}%.2f GB free out of ${bytesToGB(
         runtime.totalMemory()
-      )}%.2f GB (${bytesToGB(runtime.maxMemory())}%.2f max GB)"
+      )}%.2f GB (${bytesToGB(runtime.maxMemory())}%.2f GB max, ${bytesToGB(memoryUsed)}%.2f GB used)"
   }
 }

--- a/src/main/scala/org/renci/babel/validator/Comparer.scala
+++ b/src/main/scala/org/renci/babel/validator/Comparer.scala
@@ -103,7 +103,7 @@ object Comparer extends LazyLogging {
         val prevIdentifiers =
           prevRecords.flatMap(_.identifiers).map(_.i).toSeq.sorted
         val overlapIdentifiers =
-          identifiers.flatten.intersect(prevIdentifiers.flatten)
+          identifiers.flatten.intersect(prevIdentifiers.flatten).filterNot(_ != id)
 
         if (identifiers == prevIdentifiers) "CHANGED_WITH_IDENTICAL_IDENTIFIERS"
         else if (overlapIdentifiers.nonEmpty)

--- a/src/main/scala/org/renci/babel/validator/Comparer.scala
+++ b/src/main/scala/org/renci/babel/validator/Comparer.scala
@@ -145,7 +145,7 @@ object Comparer extends LazyLogging {
     }
 
     def writeToFile(w: Writer) = {
-      w.write("== ${filename} ==\n")
+      w.write(s"== ${filename} ==\n")
       w.write(countsByStatus + "\n\n")
 
       comparisons

--- a/src/main/scala/org/renci/babel/validator/Comparer.scala
+++ b/src/main/scala/org/renci/babel/validator/Comparer.scala
@@ -143,7 +143,7 @@ object Comparer extends LazyLogging {
           .groupBy(_.status)
           .map({ case (status, clusterComparisons) =>
             s"  === ${status} [${clusterComparisons.size}] ===\n" +
-              clusterComparisons.map(c => s" - ${c.toString}").mkString("\n")
+              clusterComparisons.map(c => s"   - ${c.toString}").mkString("\n")
           })
           .mkString("\n")
     }

--- a/src/main/scala/org/renci/babel/validator/Comparer.scala
+++ b/src/main/scala/org/renci/babel/validator/Comparer.scala
@@ -130,7 +130,7 @@ object Comparer extends LazyLogging {
       s"${filename}: " + countsByStatus
     }
 
-    def countsByStatus = {
+    def countsByStatus: String = {
       comparisons.toSeq
         .map(_.status)
         .groupBy(identity)
@@ -146,7 +146,7 @@ object Comparer extends LazyLogging {
         .mkString("\n")
     }
 
-    def writeToFile(w: Writer) = {
+    def writeToFile(w: Writer): Unit = {
       w.write(s"== ${filename} ==\n")
       w.write(countsByStatus + "\n")
 

--- a/src/main/scala/org/renci/babel/validator/Comparer.scala
+++ b/src/main/scala/org/renci/babel/validator/Comparer.scala
@@ -103,7 +103,9 @@ object Comparer extends LazyLogging {
         val prevIdentifiers =
           prevRecords.flatMap(_.identifiers).map(_.i).toSeq.sorted
         val overlapIdentifiers =
-          identifiers.flatten.intersect(prevIdentifiers.flatten).filterNot(_ != id)
+          identifiers.flatten
+            .intersect(prevIdentifiers.flatten)
+            .filterNot(_ != id)
 
         if (identifiers == prevIdentifiers) "CHANGED_WITH_IDENTICAL_IDENTIFIERS"
         else if (overlapIdentifiers.nonEmpty)

--- a/src/main/scala/org/renci/babel/validator/Comparer.scala
+++ b/src/main/scala/org/renci/babel/validator/Comparer.scala
@@ -106,7 +106,8 @@ object Comparer extends LazyLogging {
           identifiers.flatten.intersect(prevIdentifiers.flatten)
 
         if (identifiers == prevIdentifiers) "CHANGED_WITH_IDENTICAL_IDENTIFIERS"
-        else if (overlapIdentifiers.nonEmpty) "CHANGED_WITH_SOME_SHARED_IDENTIFIERS"
+        else if (overlapIdentifiers.nonEmpty)
+          "CHANGED_WITH_SOME_SHARED_IDENTIFIERS"
         else "CHANGED"
       }
     }
@@ -136,19 +137,19 @@ object Comparer extends LazyLogging {
 
     def countsByStatus: String = {
       f"TOTAL: ${comparisons.size} (100.0000%%)\n" +
-      comparisons.toSeq
-        .map(_.status)
-        .groupBy(identity)
-        .map[(Int, String)]({ case (status, values) =>
-          (
-            values.size,
-            f"${status}: ${values.size} (${values.size.toDouble / comparisons.size * 100}%.4f%%)"
-          )
-        })
-        .toSeq
-        .sortBy(-_._1)
-        .map(_._2)
-        .mkString("\n")
+        comparisons.toSeq
+          .map(_.status)
+          .groupBy(identity)
+          .map[(Int, String)]({ case (status, values) =>
+            (
+              values.size,
+              f"${status}: ${values.size} (${values.size.toDouble / comparisons.size * 100}%.4f%%)"
+            )
+          })
+          .toSeq
+          .sortBy(-_._1)
+          .map(_._2)
+          .mkString("\n")
     }
 
     def writeToFile(w: Writer): Unit = {

--- a/src/main/scala/org/renci/babel/validator/Comparer.scala
+++ b/src/main/scala/org/renci/babel/validator/Comparer.scala
@@ -105,8 +105,8 @@ object Comparer extends LazyLogging {
         val overlapIdentifiers =
           identifiers.flatten.intersect(prevIdentifiers.flatten)
 
-        if (identifiers == prevIdentifiers) "CHANGED_BUT_IDENTIFIERS_IDENTICAL"
-        else if (overlapIdentifiers.nonEmpty) "CHANGED_BUT_SHARED_IDENTIFIERS"
+        if (identifiers == prevIdentifiers) "CHANGED_WITH_IDENTICAL_IDENTIFIERS"
+        else if (overlapIdentifiers.nonEmpty) "CHANGED_WITH_SOME_SHARED_IDENTIFIERS"
         else "CHANGED"
       }
     }
@@ -135,6 +135,7 @@ object Comparer extends LazyLogging {
     }
 
     def countsByStatus: String = {
+      f"TOTAL: ${comparisons.size} (100.0000%)\n" +
       comparisons.toSeq
         .map(_.status)
         .groupBy(identity)

--- a/src/main/scala/org/renci/babel/validator/Comparer.scala
+++ b/src/main/scala/org/renci/babel/validator/Comparer.scala
@@ -93,7 +93,15 @@ object Comparer extends LazyLogging {
       else if (unchanged) "UNCHANGED"
       else if (records.isEmpty && prevRecords.nonEmpty) "DELETED"
       else if (records.nonEmpty && prevRecords.isEmpty) "ADDED"
-      else "CHANGED"
+      else {
+        // The records have changed, but how? Changes in which only the labels have changed are less "severe"
+        // than ones in which identifiers have changed, so let's try to separate those.
+        val identifiers = records.flatMap(_.identifiers).map(_.i).toSeq.sorted
+        val prevIdentifiers = prevRecords.flatMap(_.identifiers).map(_.i).toSeq.sorted
+
+        if (identifiers == prevIdentifiers) "CHANGED_BUT_IDENTIFIERS_IDENTICAL"
+        else "CHANGED"
+      }
     }
     override val toString: String = if (unchanged) {
       s"${id}\t${status}\t${records.size}\t${prevRecords.size}"

--- a/src/main/scala/org/renci/babel/validator/Comparer.scala
+++ b/src/main/scala/org/renci/babel/validator/Comparer.scala
@@ -44,8 +44,8 @@ object Comparer extends LazyLogging {
     val added: Set[String] = typesSet -- prevTypesSet
     val deleted: Set[String] = prevTypesSet -- typesSet
     val changeString: String = (added.toSeq, deleted.toSeq) match {
-      case (Seq(), Seq()) => "No change"
-      case (added, Seq()) => s"Added: ${added}"
+      case (Seq(), Seq())   => "No change"
+      case (added, Seq())   => s"Added: ${added}"
       case (Seq(), deleted) => s"Deleted: ${deleted}"
       case (added, deleted) =>
         s"Added: ${added}, Deleted: ${deleted}"

--- a/src/main/scala/org/renci/babel/validator/Reporter.scala
+++ b/src/main/scala/org/renci/babel/validator/Reporter.scala
@@ -9,6 +9,7 @@ import zio.console.Console
 import zio.stream.{ZSink, ZStream}
 
 import java.io.{File, FileOutputStream, OutputStreamWriter}
+import java.time.LocalDateTime
 
 /** Functions for reporting on the differences between two input files.
   */
@@ -130,6 +131,9 @@ object Reporter extends LazyLogging {
           .fromFile(summaryFile.toPath)
           .contramapChunks[String](_.flatMap(_.getBytes))
       ) // Returns the number of written bytes as a Long
-      .unit // Discard the number of written bytes
+      .andThen({
+        logger.info(s"Diff completed at ${LocalDateTime.now()}")
+        ZIO.succeed()
+      })
   }
 }

--- a/src/main/scala/org/renci/babel/validator/Reporter.scala
+++ b/src/main/scala/org/renci/babel/validator/Reporter.scala
@@ -131,9 +131,10 @@ object Reporter extends LazyLogging {
           .fromFile(summaryFile.toPath)
           .contramapChunks[String](_.flatMap(_.getBytes))
       ) // Returns the number of written bytes as a Long
-      .andThen({
+      .unit // Ignore the number of written bytes
+      .andThen(ZIO.effect({
+        // Report that the diff has completed.
         logger.info(s"Diff completed at ${LocalDateTime.now()}")
-        ZIO.succeed()
-      })
+      }))
   }
 }

--- a/src/main/scala/org/renci/babel/validator/Reporter.scala
+++ b/src/main/scala/org/renci/babel/validator/Reporter.scala
@@ -101,13 +101,18 @@ object Reporter extends LazyLogging {
             // output.println(typeComparison.toString)
             val basename = filename
 
-            val osw = new OutputStreamWriter(new FileOutputStream(new File(outputDir, basename)))
+            val osw = new OutputStreamWriter(
+              new FileOutputStream(new File(outputDir, basename))
+            )
             clusterComparison.writeToFile(osw)
             osw.close()
 
-            logger.info(f"Wrote ${clusterComparison.comparisons.size}%,d comparisons to ${filename}.")
+            logger.info(
+              f"Wrote ${clusterComparison.comparisons.size}%,d comparisons to ${filename}."
+            )
 
-            val summary = s"== ${filename} ==\n" + clusterComparison.countsByStatus + "\n\n"
+            val summary =
+              s"== ${filename} ==\n" + clusterComparison.countsByStatus + "\n\n"
             logger.info(summary)
 
             summary
@@ -120,8 +125,11 @@ object Reporter extends LazyLogging {
         case abc =>
           ZIO.fail(new RuntimeException(s"Invalid paired summary: ${abc}"))
       }
-      .run(ZSink.fromFile(summaryFile.toPath)
-        .contramapChunks[String](_.flatMap(_.getBytes))) // Returns the number of written bytes as a Long
+      .run(
+        ZSink
+          .fromFile(summaryFile.toPath)
+          .contramapChunks[String](_.flatMap(_.getBytes))
+      ) // Returns the number of written bytes as a Long
       .unit // Discard the number of written bytes
   }
 }

--- a/src/main/scala/org/renci/babel/validator/Reporter.scala
+++ b/src/main/scala/org/renci/babel/validator/Reporter.scala
@@ -102,6 +102,8 @@ object Reporter extends LazyLogging {
             val ps = new PrintStream(new FileOutputStream(new File(outputDir, basename)))
             ps.println(clusterComparison.toString)
             ps.close()
+
+            logger.info(s"Wrote ${clusterComparison.comparisons.size} comparisons to ${filename}.")
           }
         }
         case (filename: String, _, _) if !filterFilename(conf, filename) => {

--- a/src/main/scala/org/renci/babel/validator/Reporter.scala
+++ b/src/main/scala/org/renci/babel/validator/Reporter.scala
@@ -91,7 +91,7 @@ object Reporter extends LazyLogging {
           for {
             // lengthComparison <- Comparer.compareLengths(filename, summary, prevSummary)
             // typeComparison <- Comparer.compareTypes(filename, summary, prevSummary)
-            clusterComparison <- Comparer.compareClusters(
+            clusterComparison <- Comparer.diffClustersByIDs(
               filename,
               summary,
               prevSummary,

--- a/src/main/scala/org/renci/babel/validator/Reporter.scala
+++ b/src/main/scala/org/renci/babel/validator/Reporter.scala
@@ -107,9 +107,10 @@ object Reporter extends LazyLogging {
 
             logger.info(f"Wrote ${clusterComparison.comparisons.size}%,d comparisons to ${filename}.")
 
-            logger.info(s"== ${filename} ==\n" + clusterComparison.countsByStatus + "\n")
+            val summary = s"== ${filename} ==\n" + clusterComparison.countsByStatus + "\n\n"
+            logger.info(summary)
 
-            s"== ${filename} ==\n" + clusterComparison.countsByStatus
+            summary
           }
         }
         case (filename: String, _, _) if !filterFilename(conf, filename) => {
@@ -119,8 +120,8 @@ object Reporter extends LazyLogging {
         case abc =>
           ZIO.fail(new RuntimeException(s"Invalid paired summary: ${abc}"))
       }
-      .map(_.toByte)
-      .run(ZSink.fromFile(summaryFile.toPath)) // Returns the number of written bytes as a Long
+      .run(ZSink.fromFile(summaryFile.toPath)
+        .contramapChunks[String](_.flatMap(_.getBytes))) // Returns the number of written bytes as a Long
       .unit // Discard the number of written bytes
   }
 }

--- a/src/main/scala/org/renci/babel/validator/Reporter.scala
+++ b/src/main/scala/org/renci/babel/validator/Reporter.scala
@@ -8,7 +8,7 @@ import zio.blocking.Blocking
 import zio.console.Console
 import zio.stream.ZStream
 
-import java.io.{File, FileOutputStream, PrintStream}
+import java.io.{File, FileOutputStream, OutputStreamWriter}
 
 /** Functions for reporting on the differences between two input files.
   */
@@ -99,11 +99,11 @@ object Reporter extends LazyLogging {
             // output.println(typeComparison.toString)
             val basename = filename
 
-            val ps = new PrintStream(new FileOutputStream(new File(outputDir, basename)))
-            ps.println(clusterComparison.toString)
-            ps.close()
+            val osw = new OutputStreamWriter(new FileOutputStream(new File(outputDir, basename)))
+            clusterComparison.writeToFile(osw)
+            osw.close()
 
-            logger.info(s"Wrote ${clusterComparison.comparisons.size} comparisons to ${filename}.")
+            logger.info(f"Wrote ${clusterComparison.comparisons.size}%,d comparisons to ${filename}.")
           }
         }
         case (filename: String, _, _) if !filterFilename(conf, filename) => {

--- a/src/main/scala/org/renci/babel/validator/Reporter.scala
+++ b/src/main/scala/org/renci/babel/validator/Reporter.scala
@@ -78,7 +78,7 @@ object Reporter extends LazyLogging {
 
     val pairedSummaries =
       retrievePairedCompendiaSummaries(babelOutput, babelPrevOutput)
-    output.println("Filename\tCount\tPrevCount\tDiff\tPercentageChange")
+    // output.println("Filename\tCount\tPrevCount\tDiff\tPercentageChange")
     ZStream
       .fromIterable(pairedSummaries)
       .mapMPar(conf.nCores()) {

--- a/src/main/scala/org/renci/babel/validator/Reporter.scala
+++ b/src/main/scala/org/renci/babel/validator/Reporter.scala
@@ -91,11 +91,13 @@ object Reporter extends LazyLogging {
           ) if filterFilename(conf, filename) => {
 
           for {
-            lengthComparison <- Comparer.compareLengths(filename, summary, prevSummary)
-            typeComparison <- Comparer.compareTypes(filename, summary, prevSummary)
+            // lengthComparison <- Comparer.compareLengths(filename, summary, prevSummary)
+            // typeComparison <- Comparer.compareTypes(filename, summary, prevSummary)
+            clusterComparison <- Comparer.compareClusters(filename, summary, prevSummary)
           } yield {
-            output.println(lengthComparison.toString)
-            output.println(typeComparison.toString)
+            // output.println(lengthComparison.toString)
+            // output.println(typeComparison.toString)
+            output.println(clusterComparison.toString)
           }
         }
         case (filename: String, _, _) if !filterFilename(conf, filename) => {

--- a/src/main/scala/org/renci/babel/validator/Reporter.scala
+++ b/src/main/scala/org/renci/babel/validator/Reporter.scala
@@ -81,7 +81,7 @@ object Reporter extends LazyLogging {
     output.println("Filename\tCount\tPrevCount\tDiff\tPercentageChange")
     ZStream
       .fromIterable(pairedSummaries)
-      .mapMParUnordered(conf.nCores()) {
+      .mapMPar(conf.nCores()) {
         case (
               filename: String,
               summary: Compendium,
@@ -94,7 +94,8 @@ object Reporter extends LazyLogging {
             clusterComparison <- Comparer.compareClusters(
               filename,
               summary,
-              prevSummary
+              prevSummary,
+              conf.nCores()
             )
           } yield {
             // output.println(lengthComparison.toString)

--- a/src/main/scala/org/renci/babel/validator/Reporter.scala
+++ b/src/main/scala/org/renci/babel/validator/Reporter.scala
@@ -91,7 +91,11 @@ object Reporter extends LazyLogging {
           for {
             // lengthComparison <- Comparer.compareLengths(filename, summary, prevSummary)
             // typeComparison <- Comparer.compareTypes(filename, summary, prevSummary)
-            clusterComparison <- Comparer.compareClusters(filename, summary, prevSummary)
+            clusterComparison <- Comparer.compareClusters(
+              filename,
+              summary,
+              prevSummary
+            )
           } yield {
             // output.println(lengthComparison.toString)
             // output.println(typeComparison.toString)

--- a/src/main/scala/org/renci/babel/validator/Validator.scala
+++ b/src/main/scala/org/renci/babel/validator/Validator.scala
@@ -31,7 +31,8 @@ object Validator extends zio.App with LazyLogging {
 
     val nCores: ScallopOption[Int] = opt[Int](descr = "Number of cores to use")
 
-    val output: ScallopOption[File] = opt[File](descr = "Output file")
+    val output: ScallopOption[File] = opt[File](descr = "Directory to write outputs to", default=Some(new File(".")))
+    validateFileIsDirectory(output)
 
     verify()
   }

--- a/src/main/scala/org/renci/babel/validator/Validator.scala
+++ b/src/main/scala/org/renci/babel/validator/Validator.scala
@@ -31,7 +31,10 @@ object Validator extends zio.App with LazyLogging {
 
     val nCores: ScallopOption[Int] = opt[Int](descr = "Number of cores to use")
 
-    val output: ScallopOption[File] = opt[File](descr = "Directory to write outputs to", default=Some(new File(".")))
+    val output: ScallopOption[File] = opt[File](
+      descr = "Directory to write outputs to",
+      default = Some(new File("."))
+    )
     validateFileIsDirectory(output)
 
     verify()

--- a/src/main/scala/org/renci/babel/validator/Validator.scala
+++ b/src/main/scala/org/renci/babel/validator/Validator.scala
@@ -10,6 +10,8 @@ import java.io.File
 
 object Validator extends zio.App with LazyLogging {
   class Conf(args: Seq[String]) extends ScallopConf(args) {
+    val instruction = trailArg[String]()
+
     val babelOutput: ScallopOption[File] = trailArg[File](
       descr = "The current Babel output directory",
       required = true

--- a/src/main/scala/org/renci/babel/validator/Validator.scala
+++ b/src/main/scala/org/renci/babel/validator/Validator.scala
@@ -10,7 +10,7 @@ import java.io.File
 
 object Validator extends zio.App with LazyLogging {
   class Conf(args: Seq[String]) extends ScallopConf(args) {
-    val instruction = trailArg[String]()
+    val instruction: ScallopOption[String] = trailArg[String]()
 
     val babelOutput: ScallopOption[File] = trailArg[File](
       descr = "The current Babel output directory",

--- a/src/main/scala/org/renci/babel/validator/Validator.scala
+++ b/src/main/scala/org/renci/babel/validator/Validator.scala
@@ -16,9 +16,10 @@ object Validator extends zio.App with LazyLogging {
       descr = "The current Babel output directory",
       required = true
     )
+    validateFileIsDirectory(babelOutput)
+
     val babelPrevOutput: ScallopOption[File] =
       trailArg[File](descr = "The previous Babel output", required = true)
-    validateFileIsDirectory(babelOutput)
     validateFileIsDirectory(babelPrevOutput)
 
     val filterIn: ScallopOption[List[String]] = opt[List[String]](descr =

--- a/src/main/scala/org/renci/babel/validator/model/BabelOutput.scala
+++ b/src/main/scala/org/renci/babel/validator/model/BabelOutput.scala
@@ -21,7 +21,7 @@ class BabelOutput(root: File) {
     val dir = new File(root, dirName)
     val filenames = dir.list()
     // TODO: this would be a good place to look for out-of-place files.
-    filenames
+    filenames.toSeq
   }
 
   /** The compendia directory in this BabelOutput.

--- a/src/main/scala/org/renci/babel/validator/model/Compendium.scala
+++ b/src/main/scala/org/renci/babel/validator/model/Compendium.scala
@@ -10,6 +10,7 @@ import zio.stream._
 import java.io.File
 
 object Compendium extends LazyLogging {
+
   /** An identifier in this compendium. */
   case class Identifier(
       i: Option[String],

--- a/src/main/scala/org/renci/babel/validator/model/Compendium.scala
+++ b/src/main/scala/org/renci/babel/validator/model/Compendium.scala
@@ -4,35 +4,12 @@ import com.typesafe.scalalogging.LazyLogging
 import org.renci.babel.validator.model.Compendium.{Identifier, Record}
 import zio.ZIO
 import zio.blocking.Blocking
-import zio.stream._
 import zio.json._
+import zio.stream._
 
 import java.io.File
-import scala.collection.mutable
 
 object Compendium extends LazyLogging {
-
-  /** Quick-and-dirty memoize() implementation from
-    * https://stackoverflow.com/a/36960228/27310 This should probably be
-    * replaced with ZIO Cache or ScalaCache at some point.
-    *
-    * @param f
-    *   The function to memoize.
-    * @tparam I
-    *   The input type
-    * @tparam O
-    *   The output type
-    * @return
-    *   A function that will either return the cached value or calculate and
-    *   cache it.
-    */
-  def memoize[I, O](f: I => O): I => O = new mutable.HashMap[I, O]() {
-    override def apply(key: I) = {
-      logger.debug(s"Caching ${f}(${key}), already cached: ${contains(key)}")
-      getOrElseUpdate(key, f(key))
-    }
-  }
-
   /** An identifier in this compendium. */
   case class Identifier(
       i: Option[String],

--- a/src/main/scala/org/renci/babel/validator/model/Compendium.scala
+++ b/src/main/scala/org/renci/babel/validator/model/Compendium.scala
@@ -35,10 +35,10 @@ object Compendium extends LazyLogging {
 
   /** An identifier in this compendium. */
   case class Identifier(
-    i: Option[String],
-    l: Option[String]
+      i: Option[String],
+      l: Option[String]
   ) {
-    override val toString = (i, l) match {
+    override val toString: String = (i, l) match {
       case (None, None)       => s"None"
       case (Some(i), None)    => i
       case (None, Some(l))    => s"[${l}]"
@@ -48,15 +48,17 @@ object Compendium extends LazyLogging {
 
   /** A single record in this compendium. */
   case class Record(
-    `type`: String,
-    ic: Option[Double],
-    identifiers: Seq[Identifier]
+      `type`: String,
+      ic: Option[Double],
+      identifiers: Seq[Identifier]
   ) {
     val primaryId: Option[String] = identifiers.headOption.flatMap(_.i)
     val ids: Set[String] = identifiers.flatMap(_.i).toSet
-    override val toString = ic match {
-      case None => s"Record(${`type`} with ${identifiers.size} IDs: ${identifiers.mkString(", ")})"
-      case Some(ic) => s"Record(${`type`} [${ic}] with ${identifiers.size} IDs: ${identifiers.mkString(", ")})"
+    override val toString: String = ic match {
+      case None =>
+        s"Record(${`type`} with ${identifiers.size} IDs: ${identifiers.mkString(", ")})"
+      case Some(ic) =>
+        s"Record(${`type`} [${ic}] with ${identifiers.size} IDs: ${identifiers.mkString(", ")})"
     }
   }
 }

--- a/src/main/scala/org/renci/babel/validator/model/Compendium.scala
+++ b/src/main/scala/org/renci/babel/validator/model/Compendium.scala
@@ -31,7 +31,14 @@ object Compendium extends LazyLogging {
   case class Identifier(
     i: Option[String],
     l: Option[String]
-  )
+  ) {
+    override val toString = (i, l) match {
+      case (None, None)       => s"None"
+      case (Some(i), None)    => i
+      case (None, Some(l))    => s"[${l}]"
+      case (Some(i), Some(l)) => s"${i} [${l}]"
+    }
+  }
 
   /** A single record in this compendium. */
   case class Record(
@@ -41,6 +48,10 @@ object Compendium extends LazyLogging {
   ) {
     val primaryId: Option[String] = identifiers.headOption.flatMap(_.i)
     val ids: Set[String] = identifiers.flatMap(_.i).toSet
+    override val toString = ic match {
+      case None => s"Record(${`type`} with ${identifiers.size} IDs: ${identifiers.mkString(", ")})"
+      case Some(ic) => s"Record(${`type`} [${ic}] with ${identifiers.size} IDs: ${identifiers.mkString(", ")})"
+    }
   }
 }
 

--- a/src/main/scala/org/renci/babel/validator/model/Compendium.scala
+++ b/src/main/scala/org/renci/babel/validator/model/Compendium.scala
@@ -38,7 +38,10 @@ object Compendium extends LazyLogging {
     `type`: String,
     ic: Option[Double],
     identifiers: Seq[Identifier]
-  )
+  ) {
+    val primaryId: Option[String] = identifiers.headOption.flatMap(_.i)
+    val ids: Set[String] = identifiers.flatMap(_.i).toSet
+  }
 }
 
 /**


### PR DESCRIPTION
This PR is a first stab at comparing clusters between Babel runs. It does this by:
 - Making a list of all the identifiers in the current and previous run.
 - Identifying all the clusters in the current and previous run that mention that identifier.
 - Comparing the sets of clusters to see if things have changed.
 - Classifying those changes in one of the following ways:
   - `ERROR_BLANK`: for some reason, both previous and current clusters are empty.
   - `UNCHANGED`: both previous and current clusters are identical, i.e. the identifier is unchanged.
   - `DELETED`: the identifier is present in one or more previous clusters and no current clusters, i.e. the identifier has been deleted.
   - `ADDED`: the identifier is present in one or more current clusters and no previous clusters, i.e. the identifier has been added.
   - `CHANGED_WITH_IDENTICAL_IDENTIFIERS`: there are differences between the previous and current clusters, but the set of identifiers is identical, so it looks like only the labels have changed.
   - `CHANGED_WITH_SOME_SHARED_IDENTIFIERS`: at least one other identifier (not counting the identifier being compared) is shared between the previous and current clusters.
   - `CHANGED`: any other comparison not listed above.