### PR TITLE
Add SAPBert export to Babel Validator

### DIFF
--- a/src/main/scala/org/renci/babel/utils/converter/Converter.scala
+++ b/src/main/scala/org/renci/babel/utils/converter/Converter.scala
@@ -190,9 +190,9 @@ object Converter extends LazyLogging {
         val cliqueLeader = record.identifiers.head
         val otherIdentifiers = record.identifiers.tail
 
-        logger.debug(s"Record: ${record}")
-        logger.debug(s" - Clique leader: ${cliqueLeader}")
-        logger.debug(s" - Others: ${otherIdentifiers}")
+        // logger.debug(s"Record: ${record}")
+        // logger.debug(s" - Clique leader: ${cliqueLeader}")
+        // logger.debug(s" - Others: ${otherIdentifiers}")
 
         val predicateId = "skos:exactMatch"
         val subjectString = s"${cliqueLeader.i.getOrElse("")}\t${cliqueLeader.l

--- a/src/main/scala/org/renci/babel/utils/converter/Converter.scala
+++ b/src/main/scala/org/renci/babel/utils/converter/Converter.scala
@@ -114,7 +114,7 @@ object Converter extends LazyLogging {
 
       val namesForId = record.identifiers.flatMap(_.l) ++ (synonymsForId match {
         case Seq() => {
-          logger.debug(s"No synonyms found for clique ${record} in compendium ${compendium}")
+          // logger.debug(s"No synonyms found for clique ${record} in compendium ${compendium}")
           Seq()
         }
         case synonyms: Seq[Synonym] => synonyms.map(_.synonym)

--- a/src/main/scala/org/renci/babel/utils/converter/Converter.scala
+++ b/src/main/scala/org/renci/babel/utils/converter/Converter.scala
@@ -186,7 +186,7 @@ object Converter extends LazyLogging {
         ZStream
           .fromIterable(limitedNamePairs)
           .map({ case (name1, name2) =>
-            s"${record.`type`}||${primaryId}||${name1}||${name2}}"
+            s"${record.`type`}||${primaryId}||${name1}||${name2}"
           })
       })
       .intersperse("\n")

--- a/src/main/scala/org/renci/babel/utils/converter/Converter.scala
+++ b/src/main/scala/org/renci/babel/utils/converter/Converter.scala
@@ -106,7 +106,7 @@ object Converter extends LazyLogging {
     }
 
     compendium.records.flatMap(record => {
-      // For this, we should only need to use the primary ID, but hey, while we're here, let's go for everything.
+      // For this, we should only need to use the primary ID, but hey, while we're here, let's try all the identifiers.
       val synonymsForId = record.identifiers
         .filter(!_.i.isEmpty)
         .flatMap(id => synonymsById.get(id.i.get))
@@ -114,12 +114,16 @@ object Converter extends LazyLogging {
 
       val namesForId = record.identifiers.flatMap(_.l) ++ (synonymsForId match {
         case Seq() => {
-          logger.warn(s"No identifier found for cluster ${record} in compendium ${compendium}")
+          logger.debug(s"No synonyms found for clique ${record} in compendium ${compendium}")
           Seq()
         }
         case synonyms: Seq[Synonym] => synonyms.map(_.synonym)
       })
       val uniqueNamesForId = namesForId.toSet
+
+      if (uniqueNamesForId.isEmpty) {
+        logger.warn(s"No names found for clique ${record} in compendium ${compendium}")
+      }
 
       val labels = record.identifiers.flatMap(_.l)
       val primaryLabel = labels.headOption

--- a/src/main/scala/org/renci/babel/utils/converter/Converter.scala
+++ b/src/main/scala/org/renci/babel/utils/converter/Converter.scala
@@ -170,13 +170,13 @@ object Converter extends LazyLogging {
         val uniqueNamePairs = namePairs.filter(n => n._1 != n._2).toSet
         val limitedNamePairs = uniqueNamePairs.take(conf.maxPairsPerConcept())
         if (uniqueNamePairs.size > conf.maxPairsPerConcept()) {
-          logger.warn(s"Found ${uniqueNamePairs.size} randomized name pairs for ${primaryId}, reduced to ${limitedNamePairs.size}.")
+          // logger.warn(s"Found ${uniqueNamePairs.size} randomized name pairs for ${primaryId}, reduced to ${limitedNamePairs.size}.")
         }
 
-        logger.info(s"For ${primaryId}, found unique names ${uniqueNamesForId}, resulting in randomized pairs: ${limitedNamePairs}")
+        // logger.info(s"For ${primaryId}, found unique names ${uniqueNamesForId}, resulting in randomized pairs: ${limitedNamePairs}")
 
         ZStream
-          .fromIterable(uniqueNamePairs)
+          .fromIterable(limitedNamePairs)
           .map({ case (name1, name2) =>
             s"${record.`type`}||${primaryId}||${name1}||${name2}}"
           })

--- a/src/main/scala/org/renci/babel/utils/converter/Converter.scala
+++ b/src/main/scala/org/renci/babel/utils/converter/Converter.scala
@@ -2,7 +2,10 @@ package org.renci.babel.utils.converter
 
 import com.typesafe.scalalogging.LazyLogging
 import org.renci.babel.utils.cli.Utils
-import org.renci.babel.utils.cli.Utils.{SupportsFilenameFiltering, filterFilename}
+import org.renci.babel.utils.cli.Utils.{
+  SupportsFilenameFiltering,
+  filterFilename
+}
 import org.renci.babel.utils.model.{BabelOutput, Compendium, Synonym, Synonyms}
 import org.rogach.scallop.{ScallopOption, Subcommand}
 import zio.ZIO
@@ -41,7 +44,8 @@ object Converter extends LazyLogging {
 
     val maxPairsPerConcept: ScallopOption[Int] = opt[Int](
       descr = "Maximum number of pairs of synonyms to produce for each concept",
-      default = Some(50))
+      default = Some(50)
+    )
 
     val lowercaseNames: ScallopOption[Boolean] = opt[Boolean](
       descr = "Lowercase all the labels and synonyms",
@@ -150,8 +154,12 @@ object Converter extends LazyLogging {
             }
             case synonyms: Seq[Synonym] => synonyms.map(_.synonym)
           })
-        val uniqueNamesForId = if (conf.lowercaseNames()) namesForId.toSet.map({ n: String => n.toLowerCase }) else
-          namesForId.toSet
+        val uniqueNamesForId =
+          if (conf.lowercaseNames()) namesForId.toSet.map({ n: String =>
+            n.toLowerCase
+          })
+          else
+            namesForId.toSet
 
         if (uniqueNamesForId.isEmpty) {
           // logger.warn(s"No names found for clique ${record} in compendium ${compendium}")

--- a/src/main/scala/org/renci/babel/utils/model/BabelOutput.scala
+++ b/src/main/scala/org/renci/babel/utils/model/BabelOutput.scala
@@ -38,4 +38,17 @@ class BabelOutput(root: File) {
     getFilesInDir("compendia").map(filename =>
       new Compendium(new File(compendiaDir, filename))
     )
+
+  /**
+   * The synonyms directory in this BabelOutput.
+   */
+  val synonymDir: File = new File(root, "synonyms")
+
+  /**
+   * A dictionary of synonym files in the synonyms/ directory.
+   */
+  lazy val synonyms: Map[String, Synonyms] =
+    getFilesInDir("synonyms").map(filename =>
+      (filename, new Synonyms(new File(synonymDir, filename)))
+    ).toMap
 }

--- a/src/main/scala/org/renci/babel/utils/model/BabelOutput.scala
+++ b/src/main/scala/org/renci/babel/utils/model/BabelOutput.scala
@@ -48,7 +48,7 @@ class BabelOutput(root: File) {
    * A dictionary of synonym files in the synonyms/ directory.
    */
   lazy val synonyms: Map[String, Synonyms] =
-    getFilesInDir("synonyms").map(filename =>
-      (filename, new Synonyms(new File(synonymDir, filename)))
-    ).toMap
+    getFilesInDir("synonyms")
+      .map(filename => (filename, new Synonyms(new File(synonymDir, filename))))
+      .toMap
 }

--- a/src/main/scala/org/renci/babel/utils/model/Compendium.scala
+++ b/src/main/scala/org/renci/babel/utils/model/Compendium.scala
@@ -76,6 +76,13 @@ class Compendium(file: File) extends LazyLogging {
   val path = file.toPath
 
   /**
+   * A string representation of this compendium.
+   */
+  override def toString: String = {
+    return s"Compendium(${file})"
+  }
+
+  /**
    * A ZStream of all the lines in this file as strings.
    */
   lazy val lines: ZStream[Blocking, Throwable, String] = {

--- a/src/main/scala/org/renci/babel/utils/model/Synonyms.scala
+++ b/src/main/scala/org/renci/babel/utils/model/Synonyms.scala
@@ -1,0 +1,57 @@
+package org.renci.babel.utils.model
+
+import zio.ZIO
+import zio.blocking.Blocking
+import zio.stream.{ZStream, ZTransducer}
+
+import java.io.File
+import java.nio.file.Path
+
+/**
+ * A single synonym from a synonyms file in the Compendium output.
+ */
+case class Synonym
+(
+    id: String,
+    relation: String,
+    synonym: String
+)
+
+/**
+ * A synonyms file in the Compendium output.
+ */
+class Synonyms(file: File) {
+  val filename: String = file.getName
+  val path: Path = file.toPath
+
+  /**
+   * A ZStream of all the lines in this file as strings.
+   */
+  lazy val lines: ZStream[Blocking, Throwable, String] = {
+    ZStream
+      .fromFile(path)
+      .aggregate(ZTransducer.utf8Decode)
+      .aggregate(ZTransducer.splitLines)
+  }
+
+  /**
+   * A ZStream of all the synonyms in this file.
+   */
+  lazy val synonyms: ZStream[Blocking, Throwable, Synonym] = {
+    lines.flatMap(line => {
+      val pattern = "^(.*?)\t(.*?)\t(.*)$".r
+      line match {
+        case pattern(id, relation, synonym) => ZStream.succeed(Synonym(id, relation, synonym))
+        case _ => ZStream.fail(new RuntimeException(s"Could not parse line in synonym file ${file}: ${line}"))
+      }
+    })
+  }
+
+  /**
+   * Load all of the synonyms into a Map so that they can be looked up by ID.
+   */
+    // TODO: we ignore the relation for now, but we should probably check that here.
+  lazy val synonymsById: ZIO[Blocking, Throwable, Map[String, Seq[Synonym]]] =
+    synonyms.runCollect
+      .map(chunk => chunk.map(s => (s.id, s)).groupMap(_._1)(_._2))
+}

--- a/src/main/scala/org/renci/babel/utils/model/Synonyms.scala
+++ b/src/main/scala/org/renci/babel/utils/model/Synonyms.scala
@@ -10,8 +10,7 @@ import java.nio.file.Path
 /**
  * A single synonym from a synonyms file in the Compendium output.
  */
-case class Synonym
-(
+case class Synonym(
     id: String,
     relation: String,
     synonym: String
@@ -41,8 +40,14 @@ class Synonyms(file: File) {
     lines.flatMap(line => {
       val pattern = "^(.*?)\t(.*?)\t(.*)$".r
       line match {
-        case pattern(id, relation, synonym) => ZStream.succeed(Synonym(id, relation, synonym))
-        case _ => ZStream.fail(new RuntimeException(s"Could not parse line in synonym file ${file}: ${line}"))
+        case pattern(id, relation, synonym) =>
+          ZStream.succeed(Synonym(id, relation, synonym))
+        case _ =>
+          ZStream.fail(
+            new RuntimeException(
+              s"Could not parse line in synonym file ${file}: ${line}"
+            )
+          )
       }
     })
   }
@@ -50,7 +55,7 @@ class Synonyms(file: File) {
   /**
    * Load all of the synonyms into a Map so that they can be looked up by ID.
    */
-    // TODO: we ignore the relation for now, but we should probably check that here.
+  // TODO: we ignore the relation for now, but we should probably check that here.
   lazy val synonymsById: ZIO[Blocking, Throwable, Map[String, Seq[Synonym]]] =
     synonyms.runCollect
       .map(chunk => chunk.map(s => (s.id, s)).groupMap(_._1)(_._2))


### PR DESCRIPTION
This PR adds functionality to the Babel Validator's Converter to support exporting Babel Outputs in the format used for training SAPBert, which is a [very simple pipe-delimited format](https://github.com/cambridgeltl/sapbert/blob/ac6412795bc817cf37ec630352fa6ada230e7283/training_data/generate_pretraining_data.ipynb) in the format:

```csv
biolink:ChemicalMixture||CHEBI:75782||Vitamin B and/or vitamin B derivative-containing product||Vitamin B complex preps
biolink:ChemicalMixture||CHEBI:75782||Vitamin B Complex||Vitamin B complex
biolink:ChemicalMixture||CHEBI:75782||VITAMIN B||b vitamin complex
biolink:ChemicalMixture||CHEBI:75782||Vitamin B and/or vitamin B derivative (substance)||vitamin B complex
biolink:ChemicalMixture||CHEBI:75782||B Vitamins||b vitamin complex
biolink:ChemicalMixture||CHEBI:75782||Product containing vitamin B and/or vitamin B derivative (product)||Vitamin B- Complex
```

Note that these are pairs of valid synonyms (we treat labels as synonyms). The trickiest part of this is that if there are more than a certain number of pairs, we randomly trim the list to that limit (by default, 50, the same used in the SAPBERT paper).