### PR TITLE
Add basic validator

### DIFF
--- a/src/main/scala/org/renci/babel/utils/cli/CLI.scala
+++ b/src/main/scala/org/renci/babel/utils/cli/CLI.scala
@@ -2,6 +2,7 @@ package org.renci.babel.utils.cli
 
 import com.typesafe.scalalogging.{LazyLogging, Seq}
 import org.renci.babel.utils.converter.Converter
+import org.renci.babel.utils.validator.Validator
 import org.rogach.scallop.ScallopConf
 import zio.blocking.Blocking
 import zio.console.Console
@@ -26,6 +27,7 @@ object CLI extends zio.App with LazyLogging {
    *   The command-line arguments to this application.
    */
   class Conf(args: Seq[String]) extends ScallopConf(args) {
+    addSubcommand(new Validator.ValidateSubcommand())
     addSubcommand(new DiffReporter.DiffSubcommand())
     addSubcommand(new Converter.ConvertSubcommand())
     requireSubcommand()
@@ -47,6 +49,8 @@ object CLI extends zio.App with LazyLogging {
         DiffReporter.diffResults(diff).exitCode
       case Some(convert: Converter.ConvertSubcommand) =>
         Converter.convert(convert).exitCode
+      case Some(validate: Validator.ValidateSubcommand) =>
+        Validator.validate(validate).exitCode
       case a =>
         ZIO.fail(s"Error: no subcommand provided or invalid ($a)").exitCode
     }

--- a/src/main/scala/org/renci/babel/utils/converter/Converter.scala
+++ b/src/main/scala/org/renci/babel/utils/converter/Converter.scala
@@ -190,9 +190,9 @@ object Converter extends LazyLogging {
         val cliqueLeader = record.identifiers.head
         val otherIdentifiers = record.identifiers.tail
 
-        logger.debug(s"Record: ${record}")
-        logger.debug(s" - Clique leader: ${cliqueLeader}")
-        logger.debug(s" - Others: ${otherIdentifiers}")
+        // logger.debug(s"Record: ${record}")
+        // logger.debug(s" - Clique leader: ${cliqueLeader}")
+        // logger.debug(s" - Others: ${otherIdentifiers}")
 
         val predicateId = "skos:exactMatch"
         val subjectString = s"${cliqueLeader.i.getOrElse("")}\t${cliqueLeader.l

--- a/src/main/scala/org/renci/babel/utils/converter/Converter.scala
+++ b/src/main/scala/org/renci/babel/utils/converter/Converter.scala
@@ -114,7 +114,7 @@ object Converter extends LazyLogging {
 
       val namesForId = record.identifiers.flatMap(_.l) ++ (synonymsForId match {
         case Seq() => {
-          logger.debug(s"No synonyms found for clique ${record} in compendium ${compendium}")
+          // logger.debug(s"No synonyms found for clique ${record} in compendium ${compendium}")
           Seq()
         }
         case synonyms: Seq[Synonym] => synonyms.map(_.synonym)

--- a/src/main/scala/org/renci/babel/utils/converter/Converter.scala
+++ b/src/main/scala/org/renci/babel/utils/converter/Converter.scala
@@ -106,7 +106,7 @@ object Converter extends LazyLogging {
     }
 
     compendium.records.flatMap(record => {
-      // For this, we should only need to use the primary ID, but hey, while we're here, let's go for everything.
+      // For this, we should only need to use the primary ID, but hey, while we're here, let's try all the identifiers.
       val synonymsForId = record.identifiers
         .filter(!_.i.isEmpty)
         .flatMap(id => synonymsById.get(id.i.get))
@@ -114,12 +114,16 @@ object Converter extends LazyLogging {
 
       val namesForId = record.identifiers.flatMap(_.l) ++ (synonymsForId match {
         case Seq() => {
-          logger.warn(s"No identifier found for cluster ${record} in compendium ${compendium}")
+          logger.debug(s"No synonyms found for clique ${record} in compendium ${compendium}")
           Seq()
         }
         case synonyms: Seq[Synonym] => synonyms.map(_.synonym)
       })
       val uniqueNamesForId = namesForId.toSet
+
+      if (uniqueNamesForId.isEmpty) {
+        logger.warn(s"No names found for clique ${record} in compendium ${compendium}")
+      }
 
       val labels = record.identifiers.flatMap(_.l)
       val primaryLabel = labels.headOption

--- a/src/main/scala/org/renci/babel/utils/converter/Converter.scala
+++ b/src/main/scala/org/renci/babel/utils/converter/Converter.scala
@@ -170,13 +170,13 @@ object Converter extends LazyLogging {
         val uniqueNamePairs = namePairs.filter(n => n._1 != n._2).toSet
         val limitedNamePairs = uniqueNamePairs.take(conf.maxPairsPerConcept())
         if (uniqueNamePairs.size > conf.maxPairsPerConcept()) {
-          logger.warn(s"Found ${uniqueNamePairs.size} randomized name pairs for ${primaryId}, reduced to ${limitedNamePairs.size}.")
+          // logger.warn(s"Found ${uniqueNamePairs.size} randomized name pairs for ${primaryId}, reduced to ${limitedNamePairs.size}.")
         }
 
-        logger.info(s"For ${primaryId}, found unique names ${uniqueNamesForId}, resulting in randomized pairs: ${limitedNamePairs}")
+        // logger.info(s"For ${primaryId}, found unique names ${uniqueNamesForId}, resulting in randomized pairs: ${limitedNamePairs}")
 
         ZStream
-          .fromIterable(uniqueNamePairs)
+          .fromIterable(limitedNamePairs)
           .map({ case (name1, name2) =>
             s"${record.`type`}||${primaryId}||${name1}||${name2}}"
           })

--- a/src/main/scala/org/renci/babel/utils/converter/Converter.scala
+++ b/src/main/scala/org/renci/babel/utils/converter/Converter.scala
@@ -2,7 +2,10 @@ package org.renci.babel.utils.converter
 
 import com.typesafe.scalalogging.LazyLogging
 import org.renci.babel.utils.cli.Utils
-import org.renci.babel.utils.cli.Utils.{SupportsFilenameFiltering, filterFilename}
+import org.renci.babel.utils.cli.Utils.{
+  SupportsFilenameFiltering,
+  filterFilename
+}
 import org.renci.babel.utils.model.{BabelOutput, Compendium, Synonym, Synonyms}
 import org.rogach.scallop.{ScallopOption, Subcommand}
 import zio.ZIO
@@ -41,7 +44,8 @@ object Converter extends LazyLogging {
 
     val maxPairsPerConcept: ScallopOption[Int] = opt[Int](
       descr = "Maximum number of pairs of synonyms to produce for each concept",
-      default = Some(50))
+      default = Some(50)
+    )
 
     val lowercaseNames: ScallopOption[Boolean] = opt[Boolean](
       descr = "Lowercase all the labels and synonyms",
@@ -150,8 +154,12 @@ object Converter extends LazyLogging {
             }
             case synonyms: Seq[Synonym] => synonyms.map(_.synonym)
           })
-        val uniqueNamesForId = if (conf.lowercaseNames()) namesForId.toSet.map({ n: String => n.toLowerCase }) else
-          namesForId.toSet
+        val uniqueNamesForId =
+          if (conf.lowercaseNames()) namesForId.toSet.map({ n: String =>
+            n.toLowerCase
+          })
+          else
+            namesForId.toSet
 
         if (uniqueNamesForId.isEmpty) {
           // logger.warn(s"No names found for clique ${record} in compendium ${compendium}")

--- a/src/main/scala/org/renci/babel/utils/model/BabelOutput.scala
+++ b/src/main/scala/org/renci/babel/utils/model/BabelOutput.scala
@@ -21,6 +21,7 @@ class BabelOutput(root: File) {
    */
   def getFilesInDir(dirName: String): Seq[String] = {
     val dir = new File(root, dirName)
+    if (!dir.exists()) return Seq()
     val filenames = dir.list()
     // TODO: this would be a good place to look for out-of-place files.
     filenames.toSeq
@@ -51,4 +52,15 @@ class BabelOutput(root: File) {
     getFilesInDir("synonyms")
       .map(filename => (filename, new Synonyms(new File(synonymDir, filename))))
       .toMap
+
+  /**
+   * The conflations directory in this BabelOutput.
+   */
+  val conflationsDir: File = new File(root, "conflations")
+
+  /**
+   * A list of conflations in the conflations/ directory.
+   */
+  lazy val conflations: Seq[String] =
+    getFilesInDir("conflations")
 }

--- a/src/main/scala/org/renci/babel/utils/model/BabelOutput.scala
+++ b/src/main/scala/org/renci/babel/utils/model/BabelOutput.scala
@@ -56,7 +56,7 @@ class BabelOutput(root: File) {
   /**
    * The conflations directory in this BabelOutput.
    */
-  val conflationsDir: File = new File(root, "conflations")
+  val conflationsDir: File = new File(root, "conflation")
 
   /**
    * A list of conflations in the conflations/ directory.

--- a/src/main/scala/org/renci/babel/utils/model/BabelOutput.scala
+++ b/src/main/scala/org/renci/babel/utils/model/BabelOutput.scala
@@ -38,4 +38,17 @@ class BabelOutput(root: File) {
     getFilesInDir("compendia").map(filename =>
       new Compendium(new File(compendiaDir, filename))
     )
+
+  /**
+   * The synonyms directory in this BabelOutput.
+   */
+  val synonymDir: File = new File(root, "synonyms")
+
+  /**
+   * A dictionary of synonym files in the synonyms/ directory.
+   */
+  lazy val synonyms: Map[String, Synonyms] =
+    getFilesInDir("synonyms").map(filename =>
+      (filename, new Synonyms(new File(synonymDir, filename)))
+    ).toMap
 }

--- a/src/main/scala/org/renci/babel/utils/model/BabelOutput.scala
+++ b/src/main/scala/org/renci/babel/utils/model/BabelOutput.scala
@@ -62,5 +62,7 @@ class BabelOutput(root: File) {
    * A list of conflations in the conflations/ directory.
    */
   lazy val conflations: Seq[Conflations] =
-    getFilesInDir("conflations").map(filename => new Conflations(new File(conflationsDir, filename)))
+    getFilesInDir("conflations").map(filename =>
+      new Conflations(new File(conflationsDir, filename))
+    )
 }

--- a/src/main/scala/org/renci/babel/utils/model/BabelOutput.scala
+++ b/src/main/scala/org/renci/babel/utils/model/BabelOutput.scala
@@ -48,7 +48,7 @@ class BabelOutput(root: File) {
    * A dictionary of synonym files in the synonyms/ directory.
    */
   lazy val synonyms: Map[String, Synonyms] =
-    getFilesInDir("synonyms").map(filename =>
-      (filename, new Synonyms(new File(synonymDir, filename)))
-    ).toMap
+    getFilesInDir("synonyms")
+      .map(filename => (filename, new Synonyms(new File(synonymDir, filename))))
+      .toMap
 }

--- a/src/main/scala/org/renci/babel/utils/model/BabelOutput.scala
+++ b/src/main/scala/org/renci/babel/utils/model/BabelOutput.scala
@@ -61,6 +61,6 @@ class BabelOutput(root: File) {
   /**
    * A list of conflations in the conflations/ directory.
    */
-  lazy val conflations: Seq[String] =
-    getFilesInDir("conflations")
+  lazy val conflations: Seq[Conflations] =
+    getFilesInDir("conflations").map(filename => new Conflations(new File(conflationsDir, filename)))
 }

--- a/src/main/scala/org/renci/babel/utils/model/Compendium.scala
+++ b/src/main/scala/org/renci/babel/utils/model/Compendium.scala
@@ -76,6 +76,13 @@ class Compendium(file: File) extends LazyLogging {
   val path = file.toPath
 
   /**
+   * A string representation of this compendium.
+   */
+  override def toString: String = {
+    return s"Compendium(${file})"
+  }
+
+  /**
    * A ZStream of all the lines in this file as strings.
    */
   lazy val lines: ZStream[Blocking, Throwable, String] = {

--- a/src/main/scala/org/renci/babel/utils/model/Conflations.scala
+++ b/src/main/scala/org/renci/babel/utils/model/Conflations.scala
@@ -1,0 +1,58 @@
+package org.renci.babel.utils.model
+
+import zio.ZIO
+import zio.blocking.Blocking
+import zio.stream.{ZStream, ZTransducer}
+import zio.json._
+
+import java.io.File
+import java.nio.file.Path
+
+/**
+ * A single conflation from a conflations file in the Babel output.
+ */
+case class Conflation(
+    conflatedIds: Seq[String]
+)
+
+/**
+ * A synonyms file in the Compendium output.
+ */
+class Conflations(file: File) {
+  val filename: String = file.getName
+  val path: Path = file.toPath
+
+  /**
+   * A ZStream of all the lines in this file as strings.
+   */
+  lazy val lines: ZStream[Blocking, Throwable, String] = {
+    ZStream
+      .fromFile(path)
+      .aggregate(ZTransducer.utf8Decode)
+      .aggregate(ZTransducer.splitLines)
+  }
+
+  /**
+   * A ZStream of all the synonyms in this file.
+   */
+  lazy val conflations: ZStream[Blocking, Throwable, Conflation] = {
+    val arrayDecoder = JsonDecoder[Seq[String]]
+
+    lines.zipWithIndex.flatMap({
+      case (line, index) => arrayDecoder.decodeJson(line).fold(
+        error => ZStream.fail(new RuntimeException(s"Could not parse line ${index + 1} of file ${filename}: ${error} (line: ${line})")),
+        conflatedIds => ZStream.succeed(Conflation(conflatedIds))
+      )
+    })
+  }
+
+  /**
+   * Load all of the synonyms into a Map so that they can be looked up by ID.
+   */
+  // TODO: we ignore the relation for now, but we should probably check that here.
+  lazy val conflationsById: ZIO[Blocking, Throwable, Map[String, Seq[Conflation]]] =
+    conflations.runCollect
+      .map(chunk => chunk.flatMap(s => {
+        s.conflatedIds.map { id => (id, s)}
+      }).groupMap(_._1)(_._2))
+}

--- a/src/main/scala/org/renci/babel/utils/model/Synonyms.scala
+++ b/src/main/scala/org/renci/babel/utils/model/Synonyms.scala
@@ -8,7 +8,7 @@ import java.io.File
 import java.nio.file.Path
 
 /**
- * A single synonym from a synonyms file in the Compendium output.
+ * A single synonym from a synonyms file in the Babel output.
  */
 case class Synonym(
     id: String,
@@ -17,7 +17,7 @@ case class Synonym(
 )
 
 /**
- * A synonyms file in the Compendium output.
+ * A synonyms file in the Babel output.
  */
 class Synonyms(file: File) {
   val filename: String = file.getName

--- a/src/main/scala/org/renci/babel/utils/model/Synonyms.scala
+++ b/src/main/scala/org/renci/babel/utils/model/Synonyms.scala
@@ -1,0 +1,57 @@
+package org.renci.babel.utils.model
+
+import zio.ZIO
+import zio.blocking.Blocking
+import zio.stream.{ZStream, ZTransducer}
+
+import java.io.File
+import java.nio.file.Path
+
+/**
+ * A single synonym from a synonyms file in the Compendium output.
+ */
+case class Synonym
+(
+    id: String,
+    relation: String,
+    synonym: String
+)
+
+/**
+ * A synonyms file in the Compendium output.
+ */
+class Synonyms(file: File) {
+  val filename: String = file.getName
+  val path: Path = file.toPath
+
+  /**
+   * A ZStream of all the lines in this file as strings.
+   */
+  lazy val lines: ZStream[Blocking, Throwable, String] = {
+    ZStream
+      .fromFile(path)
+      .aggregate(ZTransducer.utf8Decode)
+      .aggregate(ZTransducer.splitLines)
+  }
+
+  /**
+   * A ZStream of all the synonyms in this file.
+   */
+  lazy val synonyms: ZStream[Blocking, Throwable, Synonym] = {
+    lines.flatMap(line => {
+      val pattern = "^(.*?)\t(.*?)\t(.*)$".r
+      line match {
+        case pattern(id, relation, synonym) => ZStream.succeed(Synonym(id, relation, synonym))
+        case _ => ZStream.fail(new RuntimeException(s"Could not parse line in synonym file ${file}: ${line}"))
+      }
+    })
+  }
+
+  /**
+   * Load all of the synonyms into a Map so that they can be looked up by ID.
+   */
+    // TODO: we ignore the relation for now, but we should probably check that here.
+  lazy val synonymsById: ZIO[Blocking, Throwable, Map[String, Seq[Synonym]]] =
+    synonyms.runCollect
+      .map(chunk => chunk.map(s => (s.id, s)).groupMap(_._1)(_._2))
+}

--- a/src/main/scala/org/renci/babel/utils/model/Synonyms.scala
+++ b/src/main/scala/org/renci/babel/utils/model/Synonyms.scala
@@ -10,8 +10,7 @@ import java.nio.file.Path
 /**
  * A single synonym from a synonyms file in the Compendium output.
  */
-case class Synonym
-(
+case class Synonym(
     id: String,
     relation: String,
     synonym: String
@@ -41,8 +40,14 @@ class Synonyms(file: File) {
     lines.flatMap(line => {
       val pattern = "^(.*?)\t(.*?)\t(.*)$".r
       line match {
-        case pattern(id, relation, synonym) => ZStream.succeed(Synonym(id, relation, synonym))
-        case _ => ZStream.fail(new RuntimeException(s"Could not parse line in synonym file ${file}: ${line}"))
+        case pattern(id, relation, synonym) =>
+          ZStream.succeed(Synonym(id, relation, synonym))
+        case _ =>
+          ZStream.fail(
+            new RuntimeException(
+              s"Could not parse line in synonym file ${file}: ${line}"
+            )
+          )
       }
     })
   }
@@ -50,7 +55,7 @@ class Synonyms(file: File) {
   /**
    * Load all of the synonyms into a Map so that they can be looked up by ID.
    */
-    // TODO: we ignore the relation for now, but we should probably check that here.
+  // TODO: we ignore the relation for now, but we should probably check that here.
   lazy val synonymsById: ZIO[Blocking, Throwable, Map[String, Seq[Synonym]]] =
     synonyms.runCollect
       .map(chunk => chunk.map(s => (s.id, s)).groupMap(_._1)(_._2))

--- a/src/main/scala/org/renci/babel/utils/validator/Validator.scala
+++ b/src/main/scala/org/renci/babel/utils/validator/Validator.scala
@@ -239,7 +239,16 @@ object Validator extends LazyLogging {
                   }
                 case None => "(no identifier)"
               }
-            }).groupBy(identity).map(t => (t._1, t._2.length.toLong))
+            })
+            .groupBy(identity)
+            .map(t => {
+              val prefix = t._1
+              val prefixCount = t._2.length.toLong
+              if (prefixCount > (Int.MaxValue - 1000)) {
+                logger.error(s"Prefix ${prefix} has a prefix count (${prefixCount}) extremely close to Int.MaxValue (${Int.MaxValue}) -- the count may overflow!")
+              }
+              (prefix, prefixCount)
+            })
         } yield (typ, prefixes)
 
         val results = zio.Runtime.default.unsafeRun(resultsZS.runCollect)

--- a/src/main/scala/org/renci/babel/utils/validator/Validator.scala
+++ b/src/main/scala/org/renci/babel/utils/validator/Validator.scala
@@ -10,7 +10,7 @@ import zio.console.Console
 import zio.stream.ZStream
 
 import java.io.{File, FileWriter, PrintWriter}
-import scala.collection.Set
+import scala.collection.{Set, immutable}
 
 /**
  * Validate Babel outputs.
@@ -243,7 +243,7 @@ object Validator extends LazyLogging {
           valid,
           recordCount,
           results.map(_._1).toSet,
-          results.flatMap(_._2.groupBy(identity)).toMap.mapValues(_.size).toMap
+          results.flatMap(_._2.groupBy(identity)).map(a => (a._1, a._2.size)).toMap
         )
       })
       .runCollect
@@ -281,7 +281,7 @@ object Validator extends LazyLogging {
           .mapM({ case (filename, synonyms) =>
             for {
               uniqueCounts <- synonyms.synonyms.fold(
-                (Set[String](), Set[String](), Set[String]())
+                (immutable.Set[String](), immutable.Set[String](), immutable.Set[String]())
               ) { case ((ids, relations, syns), synonyms) =>
                 (
                   ids + synonyms.id,

--- a/src/main/scala/org/renci/babel/utils/validator/Validator.scala
+++ b/src/main/scala/org/renci/babel/utils/validator/Validator.scala
@@ -175,6 +175,7 @@ object Validator extends LazyLogging {
             .map(t => (t._1, t._2.groupMapReduce(_.prefix)(_.count)(_ + _)))
 
           pw.println("\n== get_curie_prefixes ==")
+          pw.println(prefixCounts)
           pw.println(curiePrefixCounts)
           pw.println(curiePrefixCounts.toJsonPretty)
         }

--- a/src/main/scala/org/renci/babel/utils/validator/Validator.scala
+++ b/src/main/scala/org/renci/babel/utils/validator/Validator.scala
@@ -113,13 +113,14 @@ object Validator extends LazyLogging {
           synonyms <- validateSynonyms(pw, babelOutput)
           conflations <- validateConflations(pw, babelOutput)
         } yield {
-          val successfulCompendia = compendia.filter(_.valid)
           val failedCompendia = compendia.filter(!_.valid)
 
           pw.println(s"== COMPENDIA [${compendia.size}] ==")
-          pw.println(
-            s"Validated ${successfulCompendia.size} compendia: [${successfulCompendia.map(_.compendium.filename).mkString(", ")}]"
-          )
+          compendia.foreach({compendium =>
+            pw.println(
+              s" - ${compendium.compendium.filename} [${if (compendium.valid) "valid" else "INVALID"}]: types=${compendium.types}, prefixes=${compendium.prefixes}"
+            )
+          })
           if (failedCompendia.nonEmpty) {
             val err = s"${failedCompendia.size} compendia failed validation: [${
               failedCompendia
@@ -127,7 +128,6 @@ object Validator extends LazyLogging {
                 .mkString(", ")
             }]"
             logger.error(err)
-            pw.println(err)
           }
           pw.println()
 

--- a/src/main/scala/org/renci/babel/utils/validator/Validator.scala
+++ b/src/main/scala/org/renci/babel/utils/validator/Validator.scala
@@ -166,7 +166,7 @@ object Validator extends LazyLogging {
     val compendiaFilenames = compendia.map(_.filename).toSet
     if (compendiaFilenames != EXPECTED_COMPENDIA) {
       val errorStr =
-        s"""FAIL: compendia missing
+        s"""FAIL: compendia missing or extra
             | - Expected: ${EXPECTED_COMPENDIA}
             | - Observed: ${compendiaFilenames}
             |   - Extra files: ${compendiaFilenames.diff(EXPECTED_COMPENDIA)}
@@ -250,7 +250,15 @@ object Validator extends LazyLogging {
     val synonyms = output.synonyms
     if (synonyms.keySet != EXPECTED_SYNONYMS) {
       pw.println(
-        s"FAIL: synonyms missing\n- Expected: ${EXPECTED_SYNONYMS}\n- Observed: ${synonyms.toSet}"
+        s"""FAIL: synonyms missing or extra
+           | - Expected: ${EXPECTED_SYNONYMS}
+           | - Observed: ${synonyms.keySet}
+           |   - Extra files: ${synonyms.keySet.diff(EXPECTED_SYNONYMS)}
+           |   - Missing files: ${
+          EXPECTED_SYNONYMS.diff(
+            synonyms.keySet
+          )
+        }""".stripMargin
       )
       ZIO.succeed(Seq());
     } else {
@@ -285,9 +293,18 @@ object Validator extends LazyLogging {
       output: BabelOutput
   ): ZIO[Blocking with Console, Throwable, Seq[ConflationSummary]] = {
     val conflations = output.conflations
-    if (conflations.toSet != EXPECTED_CONFLATIONS) {
+    val conflationFilenames = conflations.map(_.filename).toSet
+    if (conflationFilenames != EXPECTED_CONFLATIONS) {
       pw.println(
-        s"FAIL: conflations missing\n- Expected: ${EXPECTED_CONFLATIONS}\n- Observed: ${conflations.toSet}"
+        s"""FAIL: conflations missing or extra
+           | - Expected: ${EXPECTED_CONFLATIONS}
+           | - Observed: ${conflationFilenames}
+           |   - Extra files: ${conflationFilenames.diff(EXPECTED_CONFLATIONS)}
+           |   - Missing files: ${
+          EXPECTED_CONFLATIONS.diff(
+            conflationFilenames
+          )
+        }""".stripMargin
       )
       ZIO.succeed(Seq());
     } else {

--- a/src/main/scala/org/renci/babel/utils/validator/Validator.scala
+++ b/src/main/scala/org/renci/babel/utils/validator/Validator.scala
@@ -178,6 +178,10 @@ object Validator extends LazyLogging {
           pw.println(prefixCounts)
           pw.println(curiePrefixCounts)
           pw.println(curiePrefixCounts.toJsonPretty)
+          pw.println()
+
+          // Just in case we need to flush this to disk.
+          pw.flush()
         }
       }
   }

--- a/src/main/scala/org/renci/babel/utils/validator/Validator.scala
+++ b/src/main/scala/org/renci/babel/utils/validator/Validator.scala
@@ -1,0 +1,162 @@
+package org.renci.babel.utils.validator
+
+import com.typesafe.scalalogging.LazyLogging
+import org.renci.babel.utils.cli.Utils.SupportsFilenameFiltering
+import org.renci.babel.utils.model.BabelOutput
+import org.rogach.scallop.{ScallopOption, Subcommand}
+import zio.ZIO
+import zio.blocking.Blocking
+import zio.console.Console
+import zio.json._
+import zio.stream.ZStream
+
+import java.io.{File, FileWriter, PrintWriter}
+import scala.collection.Set
+
+/**
+ * Validate Babel outputs.
+ */
+object Validator extends LazyLogging {
+  val DEFAULT_CORES = 5;
+
+  val EXPECTED_COMPENDIA = Set(
+    "AnatomicalEntity.txt",
+    "Disease.txt",
+    "OrganismTaxon.txt",
+    "BiologicalProcess.txt",
+    "GeneFamily.txt",
+    "Pathway.txt",
+    "Cell.txt",
+    "Gene.txt",
+    "PhenotypicFeature.txt",
+    "CellularComponent.txt",
+    "GrossAnatomicalStructure.txt",
+    "Polypeptide.txt",
+    "ChemicalEntity.txt",
+    "MacromolecularComplexMixin.txt",
+    "Protein.txt",
+    "ChemicalMixture.txt",
+    "MolecularActivity.txt",
+    "SmallMolecule.txt",
+    "ComplexMolecularMixture.txt",
+    "MolecularMixture.txt",
+    "umls.txt"
+  )
+  val EXPECTED_SYNONYMS = Set(
+    "AnatomicalEntity.txt",
+    "Disease.txt",
+    "OrganismTaxon.txt",
+    "BiologicalProcess.txt",
+    "GeneFamily.txt",
+    "Pathway.txt",
+    "Cell.txt",
+    "Gene.txt",
+    "PhenotypicFeature.txt",
+    "CellularComponent.txt",
+    "GrossAnatomicalStructure.txt",
+    "Polypeptide.txt",
+    "ChemicalEntity.txt",
+    "MacromolecularComplexMixin.txt",
+    "Protein.txt",
+    "ChemicalMixture.txt",
+    "MolecularActivity.txt",
+    "SmallMolecule.txt",
+    "ComplexMolecularMixture.txt",
+    "MolecularMixture.txt",
+    "umls.txt"
+  )
+  val EXPECTED_CONFLATIONS = Set(
+    "GeneProtein.txt"
+  )
+
+  /** The subcommand that controlling converting. */
+  class ValidateSubcommand
+      extends Subcommand("validate")
+      with SupportsFilenameFiltering {
+    val babelOutput: ScallopOption[File] = trailArg[File](
+      descr = "The current Babel output directory",
+      required = true
+    )
+    validateFileIsDirectory(babelOutput)
+
+    val nCores: ScallopOption[Int] =
+      opt[Int](descr = "Number of cores to use", default = Some(DEFAULT_CORES))
+
+    val output: ScallopOption[File] =
+      opt[File](descr = "Output directory", required = true)
+    validateFileDoesNotExist(output)
+  }
+
+  def validate(
+      conf: ValidateSubcommand
+  ): ZIO[Blocking with Console, Throwable, Unit] = {
+    val babelOutput = new BabelOutput(conf.babelOutput())
+    val outputDir = conf.output()
+
+    // Create directories for compendia and synonym reports.
+    val outputCompendia = new File(outputDir, "compendia")
+    outputCompendia.mkdirs()
+
+    val outputSynonyms = new File(outputDir, "synonyms")
+    outputSynonyms.mkdirs()
+
+    val outputSynonyms = new File(outputDir, "conflation")
+    outputSynonyms.mkdirs()
+
+    // Start writing out an overall output file.
+    zio.blocking.effectBlockingIO(new PrintWriter(new FileWriter(new File(outputDir, "validation.txt"))))
+      .bracketAuto { pw =>
+        for {
+          compendiumNames <- validateCompendia(pw, babelOutput)
+          synonymNames <- validateSynonyms(pw, babelOutput)
+          conflationNames <- validateConflations(pw, babelOutput)
+        } yield {
+          logger.info(s"Validated compendia [${compendiumNames.size}]: ${compendiumNames}")
+          logger.info(s"Validated synonyms [${synonymNames.size}]: ${synonymNames}")
+          logger.info(s"Validated conflation [${conflationNames.size}]: ${conflationNames}")
+        }
+      }
+  }
+
+  def validateCompendia(pw: PrintWriter, output: BabelOutput): ZIO[Blocking with Console, Throwable, Seq[String]] = {
+    val compendia = output.compendia
+    if (compendia.toSet != EXPECTED_COMPENDIA) {
+      pw.println(s"ERROR: compendia missing\n- Expected: ${EXPECTED_COMPENDIA}\n- Observed: ${compendia.toSet}")
+      ZIO.succeed(Seq());
+    } else {
+      ZStream.fromIterable(compendia)
+        .map(compendium => {
+
+          compendium.filename
+        }).runCollect
+    }
+  }
+
+  def validateSynonyms(pw: PrintWriter, output: BabelOutput): ZIO[Blocking with Console, Throwable, Seq[String]] = {
+    val synonyms = output.synonyms
+    if (synonyms.keySet != EXPECTED_SYNONYMS) {
+      pw.println(s"ERROR: synonyms missing\n- Expected: ${EXPECTED_SYNONYMS}\n- Observed: ${synonyms.toSet}")
+      ZIO.succeed(Seq());
+    } else {
+      ZStream.fromIterable(synonyms)
+        .map({ case (filename, synonym) => {
+
+          filename
+        }}).runCollect
+    }
+  }
+
+  def validateConflations(pw: PrintWriter, output: BabelOutput): ZIO[Blocking with Console, Throwable, Seq[String]] = {
+    val conflations = output.conflations
+    if (conflations.toSet != EXPECTED_CONFLATIONS) {
+      pw.println(s"ERROR: conflations missing\n- Expected: ${EXPECTED_CONFLATIONS}\n- Observed: ${conflations.toSet}")
+      ZIO.succeed(Seq());
+    } else {
+      ZStream.fromIterable(conflations)
+        .map(conflation => {
+
+          conflation
+        }).runCollect
+    }
+  }
+}

--- a/src/main/scala/org/renci/babel/utils/validator/Validator.scala
+++ b/src/main/scala/org/renci/babel/utils/validator/Validator.scala
@@ -239,7 +239,7 @@ object Validator extends LazyLogging {
                   }
                 case None => "(no identifier)"
               }
-            }).groupBy(identity).map(t => (t._1, t._2.size))
+            }).groupBy(identity).map(t => (t._1, t._2.length.toLong))
         } yield (typ, prefixes)
 
         val results = zio.Runtime.default.unsafeRun(resultsZS.runCollect)

--- a/src/main/scala/org/renci/babel/utils/validator/Validator.scala
+++ b/src/main/scala/org/renci/babel/utils/validator/Validator.scala
@@ -244,8 +244,8 @@ object Validator extends LazyLogging {
             .map(t => {
               val prefix = t._1
               val prefixCount = t._2.length.toLong
-              if (prefixCount > (Int.MaxValue - 1000)) {
-                logger.error(s"Prefix ${prefix} has a prefix count (${prefixCount}) extremely close to Int.MaxValue (${Int.MaxValue}) -- the count may overflow!")
+              if (prefixCount < 0 || prefixCount > (Int.MaxValue - 1000)) {
+                logger.error(s"Prefix ${prefix} has a prefix count (${prefixCount}) that is negative or extremely close to Int.MaxValue (${Int.MaxValue}) -- before of Int overflow!")
               }
               (prefix, prefixCount)
             })

--- a/src/main/scala/org/renci/babel/utils/validator/Validator.scala
+++ b/src/main/scala/org/renci/babel/utils/validator/Validator.scala
@@ -19,7 +19,7 @@ import scala.collection.Set
 object Validator extends LazyLogging {
   val DEFAULT_CORES = 5;
 
-  val EXPECTED_COMPENDIA = Set(
+  val EXPECTED_COMPENDIA: Set[String] = Set(
     "AnatomicalEntity.txt",
     "Disease.txt",
     "OrganismTaxon.txt",
@@ -42,7 +42,7 @@ object Validator extends LazyLogging {
     "MolecularMixture.txt",
     "umls.txt"
   )
-  val EXPECTED_SYNONYMS = Set(
+  val EXPECTED_SYNONYMS: Set[String] = Set(
     "AnatomicalEntity.txt",
     "Disease.txt",
     "OrganismTaxon.txt",
@@ -65,7 +65,7 @@ object Validator extends LazyLogging {
     "MolecularMixture.txt",
     "umls.txt"
   )
-  val EXPECTED_CONFLATIONS = Set(
+  val EXPECTED_CONFLATIONS: Set[String] = Set(
     "GeneProtein.txt"
   )
 
@@ -113,7 +113,7 @@ object Validator extends LazyLogging {
         } yield {
           logger.info(s"Validated compendia [${compendiumNames.size}]: ${compendiumNames}")
           logger.info(s"Validated synonyms [${synonymNames.size}]: ${synonymNames}")
-          logger.info(s"Validated conflation [${conflationNames.size}]: ${conflationNames}")
+          logger.info(s"Validated conflations [${conflationNames.size}]: ${conflationNames}")
         }
       }
   }

--- a/src/main/scala/org/renci/babel/utils/validator/Validator.scala
+++ b/src/main/scala/org/renci/babel/utils/validator/Validator.scala
@@ -162,11 +162,11 @@ object Validator extends LazyLogging {
               filename: String,
               typ: String,
               prefix: String,
-              count: Int
+              count: Long
           )
           val prefixCounts = compendia.flatMap(compendium => for {
             typ <- compendium.prefixesByType.keySet
-            (prefix, count) <- compendium.prefixesByType.getOrElse(typ, Map[String, Int]())
+            (prefix, count) <- compendium.prefixesByType.getOrElse(typ, Map[String, Long]())
           } yield PrefixCount(compendium.compendium.filename, typ, prefix, count))
 
           // To simulate the /get_curie_prefixes endpoint, we want this to be in the format:
@@ -184,10 +184,10 @@ object Validator extends LazyLogging {
   case class CompendiumSummary(
       compendium: Compendium,
       valid: Boolean,
-      recordCount: Int,
+      recordCount: Long,
       types: Set[String],
-      prefixes: Map[String, Int],
-      prefixesByType: Map[String, Map[String, Int]]
+      prefixes: Map[String, Long],
+      prefixesByType: Map[String, Map[String, Long]]
   )
 
   def validateCompendia(

--- a/src/main/scala/org/renci/babel/utils/validator/Validator.scala
+++ b/src/main/scala/org/renci/babel/utils/validator/Validator.scala
@@ -109,7 +109,7 @@ object Validator extends LazyLogging {
       )
       .bracketAuto { pw =>
         for {
-          compendia <- ZIO.succeed(Seq[CompendiumSummary]()) // validateCompendia(pw, babelOutput)
+          compendia <- validateCompendia(pw, babelOutput)
           synonyms <- validateSynonyms(pw, babelOutput)
           conflations <- validateConflations(pw, babelOutput)
         } yield {

--- a/src/main/scala/org/renci/babel/utils/validator/Validator.scala
+++ b/src/main/scala/org/renci/babel/utils/validator/Validator.scala
@@ -243,7 +243,10 @@ object Validator extends LazyLogging {
           valid,
           recordCount,
           results.map(_._1).toSet,
-          results.flatMap(_._2.groupBy(identity)).map(a => (a._1, a._2.size)).toMap
+          results
+            .flatMap(_._2.groupBy(identity))
+            .map(a => (a._1, a._2.size))
+            .toMap
         )
       })
       .runCollect
@@ -267,11 +270,9 @@ object Validator extends LazyLogging {
            | - Expected: ${EXPECTED_SYNONYMS}
            | - Observed: ${synonyms.keySet}
            |   - Extra files: ${synonyms.keySet.diff(EXPECTED_SYNONYMS)}
-           |   - Missing files: ${
-          EXPECTED_SYNONYMS.diff(
+           |   - Missing files: ${EXPECTED_SYNONYMS.diff(
             synonyms.keySet
-          )
-        }""".stripMargin
+          )}""".stripMargin
       )
       ZIO.succeed(Seq());
     } else {
@@ -281,7 +282,11 @@ object Validator extends LazyLogging {
           .mapM({ case (filename, synonyms) =>
             for {
               uniqueCounts <- synonyms.synonyms.fold(
-                (immutable.Set[String](), immutable.Set[String](), immutable.Set[String]())
+                (
+                  immutable.Set[String](),
+                  immutable.Set[String](),
+                  immutable.Set[String]()
+                )
               ) { case ((ids, relations, syns), synonyms) =>
                 (
                   ids + synonyms.id,
@@ -318,11 +323,9 @@ object Validator extends LazyLogging {
            | - Expected: ${EXPECTED_CONFLATIONS}
            | - Observed: ${conflationFilenames}
            |   - Extra files: ${conflationFilenames.diff(EXPECTED_CONFLATIONS)}
-           |   - Missing files: ${
-          EXPECTED_CONFLATIONS.diff(
+           |   - Missing files: ${EXPECTED_CONFLATIONS.diff(
             conflationFilenames
-          )
-        }""".stripMargin
+          )}""".stripMargin
       )
       ZIO.succeed(Seq());
     } else {


### PR DESCRIPTION
This PR adds a `validate` command that can be used to validate Babel Outputs. At a minimum it reads through all output files, ensuring that they all exist, are non-empty and are in the right format. Most validations consist of summarizing pieces of information (unique types, unique prefixes) and writing them out in a format that can be used to compare outputs between runs, while others (see #14 for examples) test particular aspects of the file, in particular bugs that have crept into the Babel outputs previously that we can use to ensure that those bugs don't reappear.