### PR TITLE
Added tests for /reverse_lookup

### DIFF
--- a/tests/nameres/test_nameres_api.py
+++ b/tests/nameres/test_nameres_api.py
@@ -27,3 +27,51 @@ def test_openapi_json(target_info):
         validate_url(url)
     except OpenAPIValidationError as e:
         pytest.fail(f"Could not validate OpenAPI at {url}: {e}")
+
+
+def test_reverse_lookup(target_info):
+    """
+    Test the /reverse_lookup endpoint.
+
+    :param target_info: The target information for this set of tests.
+    """
+
+    nameres_url = target_info['NameResURL']
+    reverse_lookup_url = urllib.parse.urljoin(nameres_url, 'reverse_lookup')
+
+    curies_should_work = ['UBERON:8420000']
+    curies_should_not_work = ['ENSEMBL:xarg', 'ENSEMBL:ENSDARG00000111928']
+
+    # Test POST /reverse_lookup
+    response = requests.post(reverse_lookup_url, json={
+        'curies': curies_should_not_work + curies_should_work
+    })
+    assert response.ok
+    response_json = response.json()
+
+    # Confirm that we have an entry for every working CURIE.
+    for working_curie in curies_should_work:
+        assert response_json[working_curie]['curie'] == working_curie
+        assert response_json[working_curie]['preferred_name'] is not None
+        assert response_json[working_curie]['preferred_name'] != ''
+
+    # Confirm that every non-working CURIE is represented currently.
+    for not_working_curie in curies_should_not_work:
+        assert response_json[not_working_curie] == {}
+
+    # Test GET /reverse_lookup
+    response = requests.get(reverse_lookup_url, params={
+        'curies': curies_should_not_work + curies_should_work
+    })
+    assert response.ok
+    response_json = response.json()
+
+    # Confirm that we have an entry for every working CURIE.
+    for working_curie in curies_should_work:
+        assert response_json[working_curie]['curie'] == working_curie
+        assert response_json[working_curie]['preferred_name'] is not None
+        assert response_json[working_curie]['preferred_name'] != ''
+
+    # Confirm that every non-working CURIE is represented currently.
+    for not_working_curie in curies_should_not_work:
+        assert response_json[not_working_curie] == {}


### PR DESCRIPTION
This PR adds some tests for /reverse_lookup, with a particular emphasis on making sure it works correctly when given an identifier we don't know about.