### PR TITLE
Added support for only_taxa filtering

### DIFF
--- a/tests/common/google_sheet_test_cases.py
+++ b/tests/common/google_sheet_test_cases.py
@@ -30,6 +30,7 @@ class TestRow:
     Conflations: set[str]
     BiolinkClasses: set[str]
     Prefixes: set[str]
+    OnlyTaxa: set[str]
     Source: str
     SourceURL: str
     Notes: str
@@ -59,6 +60,7 @@ class TestRow:
             Conflations=set(row.get('Conflations', '').split('|')),
             BiolinkClasses=set(row.get('Biolink Classes', '').split('|')),
             Prefixes=set(row.get('Prefixes', '').split('|')),
+            OnlyTaxa=set(row.get('Only Taxa', '').split('|')),
             Source=row.get('Source', ''),
             SourceURL=row.get('Source URL', ''),
             Notes=row.get('Notes', '')

--- a/tests/nameres/test_nameres_from_gsheet.py
+++ b/tests/nameres/test_nameres_from_gsheet.py
@@ -59,6 +59,8 @@ def test_label(target_info, test_row, test_category):
                         only_prefixes.append(prefix)
                 request['only_prefixes'] = "|".join(only_prefixes)
                 request['exclude_prefixes'] = "|".join(exclude_prefixes)
+            if test_row.OnlyTaxa:
+                request['only_taxa'] = '|'.join(list(test_row.OnlyTaxa))
 
             test_summary = f"querying {nameres_url_lookup} with label '{label}' and biolink_type {biolink_class}"
             response = requests.get(nameres_url_lookup, params=request)


### PR DESCRIPTION
This PR adds support for only_taxa filtering to NameRes test queries.

Should be merged after PR #38.