### PR TITLE
Corrected row index in test IDs

### DIFF
--- a/tests/common/google_sheet_test_cases.py
+++ b/tests/common/google_sheet_test_cases.py
@@ -90,10 +90,12 @@ class GoogleSheetTestCases:
             for row in reader:
                 self.rows.append(row)
 
-    def test_rows(self, test_nodenorm: bool = False, test_nameres: bool = False) -> list[ParameterSet]:
+    def test_rows(self, test_id_prefix: str, test_nodenorm: bool = False, test_nameres: bool = False) -> list[ParameterSet]:
         """
         self.rows is the raw list of rows we got back from the Google Sheets. This method transforms that into
         a list of TestRows.
+
+        :param test_id_prefix: The prefix for the row ID.
 
         :return: A list of TestRows for the rows in this file.
         """
@@ -104,32 +106,35 @@ class GoogleSheetTestCases:
         for count, row in enumerate(self.rows):
             # Note that count is off by two: presumably one for the header row and one because we count from zero
             # but Google Sheets counts from one.
+            row_id = f"{test_id_prefix}:row={count + 2}"
 
             if has_nonempty_value(row):
                 tr = TestRow.from_data_row(row)
 
                 if test_nodenorm:
                     if tr.ExpectPassInNodeNorm:
-                        trows.append(pytest.param(tr))
+                        trows.append(pytest.param(tr, id=row_id))
                     else:
                         trows.append(pytest.param(
                             tr,
                             marks=pytest.mark.xfail(
                                 reason=f"Test row {count + 2} is marked as not expected to pass NodeNorm in the "
                                        f"Google Sheet: {tr}",
-                                strict=True)
+                                strict=True),
+                            id=row_id
                         ))
 
                 if test_nameres:
                     if tr.ExpectPassInNameRes:
-                        trows.append(pytest.param(tr))
+                        trows.append(pytest.param(tr, id=row_id))
                     else:
                         trows.append(pytest.param(
                             tr,
                             marks=pytest.mark.xfail(
                                 reason=f"Test row {count + 2} is marked as not expected to pass NameRes in the "
                                        f"Google Sheet: {tr}",
-                                strict=True)
+                                strict=True),
+                            id=row_id
                         ))
 
         return trows

--- a/tests/nameres/test_nameres_from_gsheet.py
+++ b/tests/nameres/test_nameres_from_gsheet.py
@@ -10,7 +10,7 @@ NAMERES_TIMEOUT = 10 # If we don't get a response in 10 seconds, that's a fail.
 gsheet = GoogleSheetTestCases()
 
 
-@pytest.mark.parametrize("test_row", gsheet.test_rows(test_nodenorm=False, test_nameres=True))
+@pytest.mark.parametrize("test_row", gsheet.test_rows('test_nameres_from_gsheet.test_label', test_nodenorm=False, test_nameres=True))
 def test_label(target_info, test_row, test_category):
     nameres_url = target_info['NameResURL']
     limit = target_info['NameResLimit']

--- a/tests/nodenorm/test_nodenorm_from_gsheet.py
+++ b/tests/nodenorm/test_nodenorm_from_gsheet.py
@@ -8,7 +8,7 @@ from common.google_sheet_test_cases import GoogleSheetTestCases, TestRow
 gsheet = GoogleSheetTestCases()
 
 
-@pytest.mark.parametrize("test_row", gsheet.test_rows(test_nodenorm=True, test_nameres=False))
+@pytest.mark.parametrize("test_row", gsheet.test_rows('test_nodenorm_from_gsheet.test_row', test_nodenorm=True, test_nameres=False))
 def test_normalization(target_info, test_row, test_category):
     nodenorm_url = target_info['NodeNormURL']
 


### PR DESCRIPTION
By default, test IDs are 0-based. This corrects them so that the row index in the file could be used to directly look up the test row in the Google Sheet.