### PR TITLE
Test preferred labels case-insensitively

### DIFF
--- a/tests/nameres/test_nameres_from_gsheet.py
+++ b/tests/nameres/test_nameres_from_gsheet.py
@@ -105,7 +105,7 @@ def test_label(target_info, test_row, test_category):
 
                 # Test the preferred label if there is one.
                 if test_row.PreferredLabel:
-                    assert top_result['label'] == test_row.PreferredLabel, f"{test_summary} returned preferred " + \
+                    assert top_result['label'].lower() == test_row.PreferredLabel.lower(), f"{test_summary} returned preferred " + \
                         f"label {top_result['label']} instead of {test_row.PreferredLabel}."
 
                 # Additionally, test the biolink_class_exclude field if there is one.

--- a/tests/nodenorm/test_nodenorm_from_gsheet.py
+++ b/tests/nodenorm/test_nodenorm_from_gsheet.py
@@ -74,8 +74,8 @@ def test_normalization(target_info, test_row, test_category):
              f"identifier {expected_id}.")
 
         # Test preferred label
-        if test_row.PreferredLabel:
-            assert result['id']['label'] == preferred_label,\
+        if preferred_label:
+            assert result['id']['label'].lower() == preferred_label.lower(),\
                 f"{test_summary} but preferred label is {result['id']['label']}, not expected label {preferred_label}."
 
         # Test Biolink types


### PR DESCRIPTION
When checking the preferred label, we now compare those case insensitively.