### PR TITLE
Turn off automatically running Scala format tests

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -1,10 +1,11 @@
 name: Scala CI
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  workflow_dispatch:
+  #  push:
+  #  branches: [ main ]
+  #  pull_request:
+  #  branches: [ main ]
 
 permissions:
   contents: read


### PR DESCRIPTION
The Scala tests don't work, and the Scala code isn't currently in use. If it isn't fully deprecated at some point, it'll still be a while before anyone will bother to clean it up.