### PR TITLE
Blocklist tests should skip if a test category is set

### DIFF
--- a/tests/nameres/test_blocklist.py
+++ b/tests/nameres/test_blocklist.py
@@ -80,7 +80,7 @@ blocklist_entries = load_blocklist_from_gsheet()
 
 
 @pytest.mark.parametrize("blocklist_entry", blocklist_entries)
-def test_check_blocklist_entry(target_info, blocklist_entry):
+def test_check_blocklist_entry(target_info, blocklist_entry, test_category):
     """
     Test whether a NameRes instance has blocked every item from a blocklist.
 
@@ -88,6 +88,11 @@ def test_check_blocklist_entry(target_info, blocklist_entry):
     """
     nameres_url = target_info['NameResURL']
     nameres_url_reverse_lookup = nameres_url + 'reverse_lookup'
+
+    # If there is any test category provided, this test is not relevant and we can skip it.
+    if test_category:
+        pytest.skip(f"Skipping blocklist entry as it is not part of any category and the category filter is set to '{test_category}'.")
+        return
 
     # Only "blocked" entries are considered, since most of the spreadsheet is things we decided _not_ to block.
     if blocklist_entry.Blocked == 'y':


### PR DESCRIPTION
This is because the blocklist tests don't have categories, so all of them should be considered to have a different category than the one specified in the filter.