### PR TITLE
Add tests for descriptions

### DIFF
--- a/tests/nodenorm/test_nodenorm_descriptions.py
+++ b/tests/nodenorm/test_nodenorm_descriptions.py
@@ -1,5 +1,7 @@
 #
 # Tests for the NodeNorm descriptions
+# Note that these tests are for NodeNorm v2.3.28 onwards, as they assume a top-level `descriptions` key with a list
+# of all unique descriptions for a clique.
 #
 import pytest
 import requests


### PR DESCRIPTION
Note that some of these tests are specific to NodeNorm v2.3.28 onwards, as they introduce a top-level `descriptions` field containing a list of all unique descriptions, so they will fail on NodeNorm v2.3.27 and earlier.