### PR TITLE
Replaced target CI with NodeNorm ES

### DIFF
--- a/tests/targets.ini
+++ b/tests/targets.ini
@@ -27,9 +27,13 @@ NameResURL = https://name-lookup.transltr.io/
 NodeNormURL = https://nodenorm.test.transltr.io/
 NameResURL = https://name-lookup.test.transltr.io/
 
-[ci]
+[ci-redis]
 NodeNormURL = https://nodenorm.ci.transltr.io/
 NameResURL = https://name-lookup.ci.transltr.io/
+
+[ci]
+NodeNormURL = https://nodenorm-es.ci.transltr.io/
+NameResURL = https://namelookup-es.ci.transltr.io/
 
 [dev]
 NodeNormURL = https://nodenormalization-sri.renci.org/


### PR DESCRIPTION
I'll keep CI Redis around as [ci-redis] until we remove it entirely.