### PR TITLE
Move Blocklist code into tests.common

### DIFF
--- a/tests/common/blocklist.py
+++ b/tests/common/blocklist.py
@@ -18,12 +18,12 @@ class BlocklistEntry:
     """
     Query: Optional[str] = None
     CURIE: Optional[str] = None
-    Blocked: str = None
-    Status: str = None
-    Issue: str = None
-    TreatsOnly: str = None
-    Submitter: str = None
-    Comment: str = None
+    Blocked: Optional[str] = None
+    Status: Optional[str] = None
+    Issue: Optional[str] = None
+    TreatsOnly: Optional[str] = None
+    Submitter: Optional[str] = None
+    Comment: Optional[str] = None
 
     def is_blocked(self):
         """ Is this term supposed to be blocked? """

--- a/tests/common/blocklist.py
+++ b/tests/common/blocklist.py
@@ -60,7 +60,8 @@ def load_blocklist_from_gsheet():
     google_sheet_id = '1UR2eplHBvFRwaSIVOhlB44wpfNPY1z7AVzUkqzDqIWA'
     csv_url = f"https://docs.google.com/spreadsheets/d/{google_sheet_id}/gviz/tq?tqx=out:csv&sheet=Tests"
 
-    response = requests.get(csv_url)
+    response = requests.get(csv_url, timeout=10)
+    response.raise_for_status()
     csv_content = response.text
 
     rows = []

--- a/tests/common/blocklist.py
+++ b/tests/common/blocklist.py
@@ -1,0 +1,72 @@
+import csv
+import io
+from dataclasses import dataclass
+from typing import Optional
+
+import requests
+
+
+# The Translator Blocklist is stored in a private GitHub repository; however,
+# we are currently using a spreadsheet to manage "Red Team" exercises where
+# multiple Translator members try out different offensive terms and log them
+# into a single spreadsheet. Eventually this test will support both, but since
+# my immediate need is to check the spreadsheet, I'll start with that.
+@dataclass(frozen=True)
+class BlocklistEntry:
+    """
+    A single Blocklist entry.
+    """
+    Query: Optional[str] = None
+    CURIE: Optional[str] = None
+    Blocked: str = None
+    Status: str = None
+    Issue: str = None
+    TreatsOnly: str = None
+    Submitter: str = None
+    Comment: str = None
+
+    def is_blocked(self):
+        """ Is this term supposed to be blocked? """
+        if self.Blocked is not None and self.Blocked == 'y':
+            return True
+        return False
+
+    @staticmethod
+    def from_gsheet_dict(row):
+        """
+        Given a dictionary from a row in Google Sheets, fill in the necessary fields.
+
+        :return: A BlocklistEntry with the filled in fields.
+        """
+
+        return BlocklistEntry(
+            Query=row.get('String (optional)', None),
+            CURIE=row.get('CURIE (optional)', None),
+            Blocked=row['Blocked?'],
+            Status=row['Status (Feb 21, 2024)'],
+            Issue=row['Blocklist issue'],
+            TreatsOnly=row['Block for "treats" only?'],
+            Submitter=row['Submitter'],
+            Comment=row['Comment (optional)'],
+        )
+
+
+def load_blocklist_from_gsheet():
+    """
+    Load the Blocklist from a Google Sheet.
+
+    :return: A list of BlocklistEntry.
+    """
+    google_sheet_id = '1UR2eplHBvFRwaSIVOhlB44wpfNPY1z7AVzUkqzDqIWA'
+    csv_url = f"https://docs.google.com/spreadsheets/d/{google_sheet_id}/gviz/tq?tqx=out:csv&sheet=Tests"
+
+    response = requests.get(csv_url)
+    csv_content = response.text
+
+    rows = []
+    with io.StringIO(csv_content) as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            rows.append(BlocklistEntry.from_gsheet_dict(row))
+
+    return rows

--- a/tests/nameres/test_blocklist.py
+++ b/tests/nameres/test_blocklist.py
@@ -17,7 +17,7 @@ def test_check_blocklist_entry(target_info, blocklist_entry, categories_include)
     :param target_info: The test target information.
     """
     nameres_url = target_info['NameResURL']
-    nameres_url_reverse_lookup = nameres_url + 'synonyms'
+    nameres_synonyms_url = nameres_url + 'synonyms'
 
     # If there is any test category provided, this test is not relevant and we can skip it.
     if categories_include:
@@ -41,16 +41,16 @@ def test_check_blocklist_entry(target_info, blocklist_entry, categories_include)
 
     # Someday we would like to do this with the query as well, but that would require some work.
     # So we only test the CURIE for now.
-    response = requests.get(nameres_url_reverse_lookup, params={
+    response = requests.get(nameres_synonyms_url, params={
         'preferred_curies': blocklist_entry.CURIE,
     })
     assert response.ok, (
-        f"Request to {nameres_url_reverse_lookup}?preferred_curies={blocklist_entry.CURIE} "
+        f"Request to {nameres_synonyms_url}?preferred_curies={blocklist_entry.CURIE} "
         f"failed with HTTP {response.status_code}: {response.text}"
     )
     result = response.json()[blocklist_entry.CURIE]
 
     if flag_expect_present:
-        assert result != {}, f"Expected {blocklist_entry.CURIE} to be present on {nameres_url_reverse_lookup}, but found: {result}"
+        assert result != {}, f"Expected {blocklist_entry.CURIE} to be present on {nameres_synonyms_url}, but found: {result}"
     else:
-        assert result == {}, f"Expected {blocklist_entry.CURIE} to be absent on {nameres_url_reverse_lookup}, but found: {result}"
+        assert result == {}, f"Expected {blocklist_entry.CURIE} to be absent on {nameres_synonyms_url}, but found: {result}"

--- a/tests/nameres/test_blocklist.py
+++ b/tests/nameres/test_blocklist.py
@@ -42,9 +42,12 @@ def test_check_blocklist_entry(target_info, blocklist_entry, categories_include)
     # Someday we would like to do this with the query as well, but that would require some work.
     # So we only test the CURIE for now.
     response = requests.get(nameres_url_reverse_lookup, params={
-        'curies': blocklist_entry.CURIE,
+        'preferred_curies': blocklist_entry.CURIE,
     })
-    assert response.ok
+    assert response.ok, (
+        f"Request to {nameres_url_reverse_lookup}?preferred_curies={blocklist_entry.CURIE} "
+        f"failed with HTTP {response.status_code}: {response.text}"
+    )
     result = response.json()[blocklist_entry.CURIE]
 
     if flag_expect_present:

--- a/tests/nameres/test_blocklist.py
+++ b/tests/nameres/test_blocklist.py
@@ -1,79 +1,9 @@
-import csv
-import io
 import logging
-import urllib.parse
-from dataclasses import dataclass
-from typing import Optional
 
 import requests
 import pytest
 
-
-# The Translator Blocklist is stored in a private GitHub repository; however,
-# we are currently using a spreadsheet to manage "Red Team" exercises where
-# multiple Translator members try out different offensive terms and log them
-# into a single spreadsheet. Eventually this test will support both, but since
-# my immediate need is to check the spreadsheet, I'll start with that.
-@dataclass(frozen=True)
-class BlocklistEntry:
-    """
-    A single Blocklist entry.
-    """
-    Query: Optional[str] = None
-    CURIE: Optional[str] = None
-    Blocked: str = None
-    Status: str = None
-    Issue: str = None
-    TreatsOnly: str = None
-    Submitter: str = None
-    Comment: str = None
-
-    def is_blocked(self):
-        """ Is this term supposed to be blocked? """
-        if self.Blocked is not None and self.Blocked == 'y':
-            return True
-        return False
-
-    @staticmethod
-    def from_gsheet_dict(row):
-        """
-        Given a dictionary from a row in Google Sheets, fill in the necessary fields.
-
-        :return: A BlocklistEntry with the filled in fields.
-        """
-
-        return BlocklistEntry(
-            Query=row.get('String (optional)', None),
-            CURIE=row.get('CURIE (optional)', None),
-            Blocked=row['Blocked?'],
-            Status=row['Status (Feb 21, 2024)'],
-            Issue=row['Blocklist issue'],
-            TreatsOnly=row['Block for "treats" only?'],
-            Submitter=row['Submitter'],
-            Comment=row['Comment (optional)'],
-        )
-
-
-def load_blocklist_from_gsheet():
-    """
-    Load the Blocklist from a Google Sheet.
-
-    :param google_sheet_id: The Google Sheet ID containing the blocklist.
-    :return: A list of BlocklistEntry.
-    """
-    google_sheet_id = '1UR2eplHBvFRwaSIVOhlB44wpfNPY1z7AVzUkqzDqIWA'
-    csv_url = f"https://docs.google.com/spreadsheets/d/{google_sheet_id}/gviz/tq?tqx=out:csv&sheet=Tests"
-
-    response = requests.get(csv_url)
-    csv_content = response.text
-
-    rows = []
-    with io.StringIO(csv_content) as f:
-        reader = csv.DictReader(f)
-        for row in reader:
-            rows.append(BlocklistEntry.from_gsheet_dict(row))
-
-    return rows
+from tests.common.blocklist import load_blocklist_from_gsheet
 
 # Parameterize blocklist entries.
 blocklist_entries = load_blocklist_from_gsheet()

--- a/tests/nameres/test_blocklist.py
+++ b/tests/nameres/test_blocklist.py
@@ -17,7 +17,7 @@ def test_check_blocklist_entry(target_info, blocklist_entry, categories_include)
     :param target_info: The test target information.
     """
     nameres_url = target_info['NameResURL']
-    nameres_url_reverse_lookup = nameres_url + 'reverse_lookup'
+    nameres_url_reverse_lookup = nameres_url + 'synonyms'
 
     # If there is any test category provided, this test is not relevant and we can skip it.
     if categories_include:

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,3 +1,4 @@
 # pytest.ini settings
 [pytest]
-timeout = 300 # 5 minutes
+# Timeout of 5 minutes (300 seconds)
+timeout = 300


### PR DESCRIPTION
This slims down the tests and makes it easier to use the Blocklist in other tests. Also updates the endpoint and fixes a config bug.