### PR TITLE
Make babel_validation a top-level import (drop src. prefix)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,4 +88,4 @@ When writing new tests:
 - For Google Sheet-based tests, parametrize with `gsheet.test_rows()` and use the `test_category` fixture for category filtering
 - Use `pytest.mark.xfail(strict=True)` for known failures (strict=True means unexpected passes also fail)
 - Hand-written per-issue regression tests go in `tests/nodenorm/by_issue/`
-- Import shared classes from `src.babel_validation.*` (e.g. `from src.babel_validation.services.nodenorm import CachedNodeNorm`)
+- Import shared classes from `babel_validation.*` (e.g. `from babel_validation.services.nodenorm import CachedNodeNorm`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-# Package the entire `src/` directory so existing imports
-# (`from src.babel_validation.X import Y`) continue to work after install.
-packages = ["src"]
+packages = ["src/babel_validation"]
 
 [tool.pytest.ini_options]
 # Without testpaths, a bare `pytest` would also scan the website directories

--- a/tests/nameres/test_blocklist.py
+++ b/tests/nameres/test_blocklist.py
@@ -3,7 +3,7 @@ import logging
 import requests
 import pytest
 
-from src.babel_validation.sources.google_sheets.blocklist import load_blocklist_from_gsheet
+from babel_validation.sources.google_sheets.blocklist import load_blocklist_from_gsheet
 from tests._pytest_helpers import deselected_by_markexpr
 
 # The blocklist Google Sheet is downloaded lazily in pytest_generate_tests so

--- a/tests/nameres/test_nameres_from_gsheet.py
+++ b/tests/nameres/test_nameres_from_gsheet.py
@@ -1,7 +1,7 @@
 import urllib.parse
 import requests
 import pytest
-from src.babel_validation.sources.google_sheets.google_sheet_test_cases import GoogleSheetTestCases
+from babel_validation.sources.google_sheets.google_sheet_test_cases import GoogleSheetTestCases
 from tests._pytest_helpers import deselected_by_markexpr
 
 # Configuration options

--- a/tests/nodenorm/test_nodenorm_from_gsheet.py
+++ b/tests/nodenorm/test_nodenorm_from_gsheet.py
@@ -1,7 +1,7 @@
 import urllib.parse
 import requests
 import pytest
-from src.babel_validation.sources.google_sheets.google_sheet_test_cases import GoogleSheetTestCases
+from babel_validation.sources.google_sheets.google_sheet_test_cases import GoogleSheetTestCases
 from tests._pytest_helpers import deselected_by_markexpr
 
 # The Google Sheet is downloaded lazily in pytest_generate_tests so that runs

--- a/tests/test_environment/test_env.py
+++ b/tests/test_environment/test_env.py
@@ -1,7 +1,7 @@
 # Test whether the test environment is functional.
 import json
 
-from src.babel_validation.sources.google_sheets.google_sheet_test_cases import GoogleSheetTestCases
+from babel_validation.sources.google_sheets.google_sheet_test_cases import GoogleSheetTestCases
 
 
 def test_google_sheet_has_test_cases():


### PR DESCRIPTION
## Summary

- Changes `pyproject.toml` to package `src/babel_validation` directly instead of the entire `src/` directory, so `babel_validation` is a proper top-level package after install
- Updates all 4 test-file imports from `from src.babel_validation.X import Y` to `from babel_validation.X import Y`
- Updates CLAUDE.md import example to match

The `src.` prefix in import paths was a layout detail leaking into the namespace. This is the conventional src-layout fix.

## Test plan

- [ ] `pytest tests/test_environment/` — verifies imports resolve and Google Sheet loads
- [ ] `pytest --target dev -x` — smoke-test against dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)