### PR TITLE
Track down the NodeNorm Biolink type changes on exp

### DIFF
--- a/tests/nodenorm/test_nodenorm_types.py
+++ b/tests/nodenorm/test_nodenorm_types.py
@@ -12,6 +12,55 @@ import requests
 def nodenorm_url(target_info):
     return target_info['NodeNormURL']
 
+
+def check_biolink_types(nodenorm_url, expected, conflate, drug_chemical_conflate, allowed_individual_types):
+    """
+    Query get_normalized_nodes for every CURIE in `expected` and compare the returned Biolink types.
+
+    Every mismatch across every CURIE is collected and reported in a single assertion, so that one
+    bad clique doesn't hide the others. `allowed_individual_types` is called with the types actually
+    returned for the clique and should return the set of types each equivalent identifier may have.
+    """
+    response = requests.post(nodenorm_url + "get_normalized_nodes", json={
+        "curies": list(expected.keys()),
+        "conflate": conflate,
+        "drug_chemical_conflate": drug_chemical_conflate,
+        "individual_types": True,
+    })
+    response.raise_for_status()
+    results = response.json()
+
+    errors = []
+    for curie, expected_types in expected.items():
+        result = results.get(curie)
+        if result is None:
+            errors.append(f"{curie}: no result returned")
+            continue
+
+        actual_types = result['type']
+        if actual_types != expected_types:
+            missing = [t for t in expected_types if t not in actual_types]
+            extra = [t for t in actual_types if t not in expected_types]
+            reordered = not missing and not extra
+            errors.append(
+                f"{curie}: Biolink types differ ({'reordered only' if reordered else 'membership differs'})\n"
+                f"  expected: {expected_types}\n"
+                f"  actual:   {actual_types}\n"
+                f"  missing from actual: {missing}\n"
+                f"  unexpected in actual: {extra}"
+            )
+
+        allowed = allowed_individual_types(actual_types)
+        for eq in result['equivalent_identifiers']:
+            if eq['type'] not in allowed:
+                errors.append(
+                    f"{curie}: equivalent identifier {eq['identifier']} has type {eq['type']}, "
+                    f"expected one of {sorted(allowed)}"
+                )
+
+    assert not errors, f"{len(errors)} difference(s) found:\n\n" + "\n\n".join(errors)
+
+
 def test_unconflated_biolink_types(nodenorm_url):
     """
     Check a few Biolink types without conflation turned on.
@@ -81,26 +130,14 @@ def test_unconflated_biolink_types(nodenorm_url):
         ]
     }
 
-    response = requests.post(nodenorm_url + "get_normalized_nodes", json={
-        "curies": list(curies_and_expected_results.keys()),
-        "conflate": False,
-        "drug_chemical_conflate": False,
-        "individual_types": True,
-    })
-    results = response.json()
-
-    # Pull out each Biolink types list and compare to expected results.
-    for query_curie in curies_and_expected_results.keys():
-        result = results[query_curie]
-
-        # Compare Biolink types with expected results.
-        biolink_types = result['type']
-        assert biolink_types == curies_and_expected_results[query_curie]
-
-        # Check the individual types, which -- without conflation -- should be identical to the first Biolink type.
-        first_biolink_type = biolink_types[0]
-        for equivalent_identifiers in result['equivalent_identifiers']:
-            assert equivalent_identifiers['type'] == first_biolink_type
+    # Without conflation, every individual type should be identical to the first Biolink type.
+    check_biolink_types(
+        nodenorm_url,
+        curies_and_expected_results,
+        conflate=False,
+        drug_chemical_conflate=False,
+        allowed_individual_types=lambda actual_types: {actual_types[0]},
+    )
 
 
 def test_geneprotein_conflated_biolink_types(nodenorm_url):
@@ -144,25 +181,14 @@ def test_geneprotein_conflated_biolink_types(nodenorm_url):
         ]
     }
 
-    response = requests.post(nodenorm_url + "get_normalized_nodes", json={
-        "curies": list(curies_and_expected_results.keys()),
-        "conflate": True,
-        "drug_chemical_conflate": False,
-        "individual_types": True,
-    })
-    results = response.json()
-
-    # Pull out each Biolink types list and compare to expected results.
-    for query_curie in curies_and_expected_results.keys():
-        result = results[query_curie]
-
-        # Compare Biolink types with expected results.
-        biolink_types = result['type']
-        assert biolink_types == curies_and_expected_results[query_curie]
-
-        # Check the individual types, which -- with GeneProtein conflation -- should be either 'biolink:Gene' or 'biolink:Protein'.
-        for equivalent_identifiers in result['equivalent_identifiers']:
-            assert equivalent_identifiers['type'] in {'biolink:Gene', 'biolink:Protein'}
+    # With GeneProtein conflation, every individual type should be either 'biolink:Gene' or 'biolink:Protein'.
+    check_biolink_types(
+        nodenorm_url,
+        curies_and_expected_results,
+        conflate=True,
+        drug_chemical_conflate=False,
+        allowed_individual_types=lambda actual_types: {'biolink:Gene', 'biolink:Protein'},
+    )
 
 
 def test_drugchemical_conflated_biolink_types(nodenorm_url):
@@ -200,30 +226,18 @@ def test_drugchemical_conflated_biolink_types(nodenorm_url):
         ]
     }
 
-    response = requests.post(nodenorm_url + "get_normalized_nodes", json={
-        "curies": list(curies_and_expected_results.keys()),
-        "conflate": False,
-        "drug_chemical_conflate": True,
-        "individual_types": True,
-    })
-    results = response.json()
-
-    # Pull out each Biolink types list and compare to expected results.
-    for query_curie in curies_and_expected_results.keys():
-        result = results[query_curie]
-
-        # Compare Biolink types with expected results.
-        biolink_types = result['type']
-        assert biolink_types == curies_and_expected_results[query_curie]
-
-        # Check the individual types, which -- without conflation -- should be one of the chemical types.
-        first_biolink_type = biolink_types[0]
-        for equivalent_identifiers in result['equivalent_identifiers']:
-            assert equivalent_identifiers['type'] in {
-                'biolink:Drug',
-                'biolink:SmallMolecule',
-                'biolink:ChemicalEntity',
-            }
+    # With DrugChemical conflation, every individual type should be one of the chemical types.
+    check_biolink_types(
+        nodenorm_url,
+        curies_and_expected_results,
+        conflate=False,
+        drug_chemical_conflate=True,
+        allowed_individual_types=lambda actual_types: {
+            'biolink:Drug',
+            'biolink:SmallMolecule',
+            'biolink:ChemicalEntity',
+        },
+    )
 
 
 
@@ -313,22 +327,11 @@ def test_fully_conflated_biolink_types(nodenorm_url):
         ]
     }
 
-    response = requests.post(nodenorm_url + "get_normalized_nodes", json={
-        "curies": list(curies_and_expected_results.keys()),
-        "conflate": True,
-        "drug_chemical_conflate": True,
-        "individual_types": True,
-    })
-    results = response.json()
-
-    # Pull out each Biolink types list and compare to expected results.
-    for query_curie in curies_and_expected_results.keys():
-        result = results[query_curie]
-
-        # Compare Biolink types with expected results.
-        biolink_types = result['type']
-        assert biolink_types == curies_and_expected_results[query_curie]
-
-        # Check the individual types, which -- with full conflation -- should be one of the Biolink types for the overall clique.
-        for equivalent_identifiers in result['equivalent_identifiers']:
-            assert equivalent_identifiers['type'] in biolink_types
+    # With full conflation, every individual type should be one of the Biolink types for the overall clique.
+    check_biolink_types(
+        nodenorm_url,
+        curies_and_expected_results,
+        conflate=True,
+        drug_chemical_conflate=True,
+        allowed_individual_types=set,
+    )

--- a/tests/nodenorm/test_nodenorm_types.py
+++ b/tests/nodenorm/test_nodenorm_types.py
@@ -4,6 +4,16 @@
 # is correct. These tests are intended to cover whether all the Biolink types are correct, for both normal entries
 # and conflated entries.
 #
+# The expected values below are the baseline as of NodeNorm on `exp` (2026-07-24). They differ from
+# dev/prod/test/ci, which still return the previous baseline; see the PR discussion for whether these
+# changes should be accepted or fixed in NodeNorm. The three differences are:
+#   1. `biolink:OntologyClass` is now included for cliques that previously lacked it (MESH:D014867,
+#      NCIT:C34373), inserted after the second-most-specific type.
+#   2. `biolink:GeneOrGeneProductOrGeneFamily` is a new type on gene cliques, after
+#      `biolink:GeneOrGeneProduct`.
+#   3. Because of (1), `biolink:OntologyClass` now appears in the main clique's types for
+#      MESH:D014867 rather than being appended by DrugChemical conflation, so its position moves.
+#
 
 import pytest
 import requests
@@ -69,6 +79,7 @@ def test_unconflated_biolink_types(nodenorm_url):
         "MESH:D014867": [
             "biolink:SmallMolecule",
             "biolink:MolecularEntity",
+            "biolink:OntologyClass",
             "biolink:ChemicalEntity",
             "biolink:PhysicalEssence",
             "biolink:ChemicalOrDrugOrTreatment",
@@ -80,6 +91,7 @@ def test_unconflated_biolink_types(nodenorm_url):
         "NCIT:C34373": [
             "biolink:Disease",
             "biolink:DiseaseOrPhenotypicFeature",
+            "biolink:OntologyClass",
             "biolink:BiologicalEntity",
             "biolink:ThingWithTaxon",
             "biolink:NamedThing"
@@ -87,6 +99,7 @@ def test_unconflated_biolink_types(nodenorm_url):
         "NCBIGene:22059": [
             'biolink:Gene',
             'biolink:GeneOrGeneProduct',
+            'biolink:GeneOrGeneProductOrGeneFamily',
             'biolink:GenomicEntity',
             'biolink:ChemicalEntityOrGeneOrGeneProduct',
             'biolink:PhysicalEssence',
@@ -148,6 +161,7 @@ def test_geneprotein_conflated_biolink_types(nodenorm_url):
         "NCBIGene:22059": [
             'biolink:Gene',
             'biolink:GeneOrGeneProduct',
+            'biolink:GeneOrGeneProductOrGeneFamily',
             'biolink:GenomicEntity',
             'biolink:ChemicalEntityOrGeneOrGeneProduct',
             'biolink:PhysicalEssence',
@@ -165,6 +179,7 @@ def test_geneprotein_conflated_biolink_types(nodenorm_url):
         "PR:Q9Y6J0": [
             'biolink:Gene',
             'biolink:GeneOrGeneProduct',
+            'biolink:GeneOrGeneProductOrGeneFamily',
             'biolink:GenomicEntity',
             'biolink:ChemicalEntityOrGeneOrGeneProduct',
             'biolink:PhysicalEssence',
@@ -199,6 +214,7 @@ def test_drugchemical_conflated_biolink_types(nodenorm_url):
         "MESH:D014867": [
             "biolink:SmallMolecule",
             "biolink:MolecularEntity",
+            "biolink:OntologyClass",
             "biolink:ChemicalEntity",
             "biolink:PhysicalEssence",
             "biolink:ChemicalOrDrugOrTreatment",
@@ -207,7 +223,6 @@ def test_drugchemical_conflated_biolink_types(nodenorm_url):
             "biolink:NamedThing",
             "biolink:PhysicalEssenceOrOccurrent",
             'biolink:Drug',
-            'biolink:OntologyClass',
             'biolink:MolecularMixture',
             'biolink:ChemicalMixture',
         ],
@@ -249,6 +264,7 @@ def test_fully_conflated_biolink_types(nodenorm_url):
         "MESH:D014867": [
             "biolink:SmallMolecule",
             "biolink:MolecularEntity",
+            "biolink:OntologyClass",
             "biolink:ChemicalEntity",
             "biolink:PhysicalEssence",
             "biolink:ChemicalOrDrugOrTreatment",
@@ -257,13 +273,13 @@ def test_fully_conflated_biolink_types(nodenorm_url):
             "biolink:NamedThing",
             "biolink:PhysicalEssenceOrOccurrent",
             'biolink:Drug',
-            'biolink:OntologyClass',
             'biolink:MolecularMixture',
             'biolink:ChemicalMixture',
         ],
         "NCIT:C34373": [
             "biolink:Disease",
             "biolink:DiseaseOrPhenotypicFeature",
+            "biolink:OntologyClass",
             "biolink:BiologicalEntity",
             "biolink:ThingWithTaxon",
             "biolink:NamedThing"
@@ -271,6 +287,7 @@ def test_fully_conflated_biolink_types(nodenorm_url):
         "NCBIGene:22059": [
             'biolink:Gene',
             'biolink:GeneOrGeneProduct',
+            'biolink:GeneOrGeneProductOrGeneFamily',
             'biolink:GenomicEntity',
             'biolink:ChemicalEntityOrGeneOrGeneProduct',
             'biolink:PhysicalEssence',
@@ -301,6 +318,7 @@ def test_fully_conflated_biolink_types(nodenorm_url):
         "PR:Q9Y6J0": [
             'biolink:Gene',
             'biolink:GeneOrGeneProduct',
+            'biolink:GeneOrGeneProductOrGeneFamily',
             'biolink:GenomicEntity',
             'biolink:ChemicalEntityOrGeneOrGeneProduct',
             'biolink:PhysicalEssence',


### PR DESCRIPTION
`uv run pytest --target exp tests/nodenorm/test_nodenorm_types.py` fails because the position of `biolink:OntologyClass` has changed. This PR makes those failures legible and records what actually changed, so we can decide whether to accept the new values as the baseline or fix NodeNorm.

## 1. Report every difference at once

Each of the four tests looped over its CURIEs and asserted per-CURIE, so the first mismatch aborted the test and hid the rest — tracking down the change meant fixing one expectation at a time to reveal the next.

The four near-identical request/compare blocks are now one `check_biolink_types()` helper that collects every mismatch across every CURIE into a single assertion, and distinguishes a membership change (calling out which types are missing and which are unexpected) from a pure reordering:

```
4 difference(s) found:

MESH:D014867: Biolink types differ (reordered only)
  expected: [...]
  actual:   [...]
  missing from actual: []
  unexpected in actual: []

NCIT:C34373: Biolink types differ (membership differs)
  ...
  unexpected in actual: ['biolink:OntologyClass']
```

That commit is behaviour-preserving — no expected values change.

## 2. What changed on exp

Three differences, all consistent with a Biolink model version bump rather than a change in Babel's data:

| # | Change | Affected CURIEs |
|---|--------|-----------------|
| 1 | `biolink:OntologyClass` now returned where it previously wasn't, inserted after the second-most-specific type | `MESH:D014867` (SmallMolecule), `NCIT:C34373` (Disease) — but **not** `UNII:K16AIQ8CTM` (ChemicalEntity) |
| 2 | `biolink:GeneOrGeneProductOrGeneFamily` is a new type on gene cliques, directly after `biolink:GeneOrGeneProduct` | `NCBIGene:22059`, `PR:Q9Y6J0` |
| 3 | `biolink:OntologyClass` moves from index 10 to index 2 under DrugChemical conflation | `MESH:D014867` |

(3) is the change that prompted this investigation, and it falls out of (1): `OntologyClass` now arrives with the main clique's types instead of being appended by the conflation tail. Membership is identical; only the order differs.

## Questions for review

- Is (1) intended? The inconsistency is suspicious: `MESH:D014867` and `NCIT:C34373` gained `OntologyClass`, but `UNII:K16AIQ8CTM` did not.
- Is (2) simply a new class in the Biolink model we should accept?
- Do we care about (3) at all, given the type set is unchanged? If ordering is only meaningful for the first (most specific) type, these tests may be over-asserting.

## Note on other targets

The expectations now match `exp` only. dev, prod, test and ci still return the previous baseline and so now **fail** with the exact inverse differences. That is deliberate — making the tests pass on every target would need version-conditional expectations that hide the very difference we're trying to decide on. Once exp is promoted, this should go green everywhere; if we'd rather stay on the old baseline until then, the second commit can simply be reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)